### PR TITLE
feat(engine): Render basic sector geometry

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -81,9 +81,9 @@ ECS System
 **Objectifs** : Rendu 3D fonctionnel avec géométrie secteur
 
 #### Semaine 3 : Rendu Core
-- [ ] Engine class avec lifecycle
-- [ ] WebGPU renderer + fallback WebGL2  
-- [ ] Scene manager avec transitions
+- [x] Engine class avec lifecycle
+- [x] WebGPU renderer + fallback WebGL2  
+- [x] Scene manager avec transitions
 - [ ] Asset loader (textures, modèles)
 
 #### Semaine 4 : Géométrie DOOM

--- a/packages/engine/src/core/scene-manager.ts
+++ b/packages/engine/src/core/scene-manager.ts
@@ -1,15 +1,15 @@
 import {
-  Color3,
   type Engine,
   FreeCamera,
   HemisphericLight,
-  MeshBuilder,
+  Mesh,
   Scene,
-  StandardMaterial,
   Vector2,
   Vector3,
+  VertexData,
 } from '@babylonjs/core';
 import type { DoomSector, DoomVertex } from '../geometry/doom-geometry';
+import { SectorGeometry } from '../geometry/sector-geometry';
 
 export class SceneManager {
   private engine: Engine;
@@ -43,7 +43,7 @@ export class SceneManager {
       { id: 'v4', position: new Vector2(-5, 5) },
     ];
 
-    const _sector: DoomSector = {
+    const sector: DoomSector = {
       id: 's1',
       floorHeight: 0,
       ceilingHeight: 4,
@@ -58,13 +58,17 @@ export class SceneManager {
       meshId: 'sector_s1',
     };
 
-    // TODO: In the next step, we will use SectorGeometry to create the mesh from `sector` data.
-    // For now, let's keep the ground plane to have something to see.
-    console.log('Defined test sector:', _sector); // Temporary log to avoid unused variable error
-    const ground = MeshBuilder.CreateGround('ground', { width: 10, height: 10 }, scene);
-    const groundMaterial = new StandardMaterial('groundMaterial', scene);
-    groundMaterial.diffuseColor = new Color3(0.4, 0.4, 0.4);
-    ground.material = groundMaterial;
+    // Create geometry from the sector data
+    const sectorGeometry = new SectorGeometry(sector);
+    const triangulation = sectorGeometry.triangulate();
+
+    // Create a new mesh for the sector
+    const sectorMesh = new Mesh(sector.id, scene);
+    const vertexData = new VertexData();
+    vertexData.positions = triangulation.vertices.flatMap((v) => [v.x, v.y, v.z]);
+    vertexData.indices = triangulation.indices;
+    vertexData.uvs = triangulation.uvs.flatMap((v) => [v.x, v.y]);
+    vertexData.applyToMesh(sectorMesh);
 
     this.currentScene = scene;
     return scene;

--- a/packages/engine/src/core/scene-manager.ts
+++ b/packages/engine/src/core/scene-manager.ts
@@ -1,9 +1,11 @@
 import {
+  Color3,
   type Engine,
   FreeCamera,
   HemisphericLight,
   Mesh,
   Scene,
+  StandardMaterial,
   Vector2,
   Vector3,
   VertexData,
@@ -60,15 +62,32 @@ export class SceneManager {
 
     // Create geometry from the sector data
     const sectorGeometry = new SectorGeometry(sector);
-    const triangulation = sectorGeometry.triangulate();
 
-    // Create a new mesh for the sector
-    const sectorMesh = new Mesh(sector.id, scene);
-    const vertexData = new VertexData();
-    vertexData.positions = triangulation.vertices.flatMap((v) => [v.x, v.y, v.z]);
-    vertexData.indices = triangulation.indices;
-    vertexData.uvs = triangulation.uvs.flatMap((v) => [v.x, v.y]);
-    vertexData.applyToMesh(sectorMesh);
+    // Create floor mesh
+    const floorTriangulation = sectorGeometry.triangulateFloor();
+    const floorMesh = new Mesh(`${sector.id}_floor`, scene);
+    const floorVertexData = new VertexData();
+    floorVertexData.positions = floorTriangulation.vertices.flatMap((v) => [v.x, v.y, v.z]);
+    floorVertexData.indices = floorTriangulation.indices;
+    floorVertexData.uvs = floorTriangulation.uvs.flatMap((v) => [v.x, v.y]);
+    floorVertexData.applyToMesh(floorMesh);
+
+    const floorMaterial = new StandardMaterial(`${sector.id}_floor_mat`, scene);
+    floorMaterial.diffuseColor = new Color3(0.5, 0.5, 0.5);
+    floorMesh.material = floorMaterial;
+
+    // Create ceiling mesh
+    const ceilingTriangulation = sectorGeometry.triangulateCeiling();
+    const ceilingMesh = new Mesh(`${sector.id}_ceiling`, scene);
+    const ceilingVertexData = new VertexData();
+    ceilingVertexData.positions = ceilingTriangulation.vertices.flatMap((v) => [v.x, v.y, v.z]);
+    ceilingVertexData.indices = ceilingTriangulation.indices;
+    ceilingVertexData.uvs = ceilingTriangulation.uvs.flatMap((v) => [v.x, v.y]);
+    ceilingVertexData.applyToMesh(ceilingMesh);
+
+    const ceilingMaterial = new StandardMaterial(`${sector.id}_ceiling_mat`, scene);
+    ceilingMaterial.diffuseColor = new Color3(0.2, 0.2, 0.8);
+    ceilingMesh.material = ceilingMaterial;
 
     this.currentScene = scene;
     return scene;

--- a/packages/engine/src/core/scene-manager.ts
+++ b/packages/engine/src/core/scene-manager.ts
@@ -6,8 +6,10 @@ import {
   MeshBuilder,
   Scene,
   StandardMaterial,
+  Vector2,
   Vector3,
 } from '@babylonjs/core';
+import type { DoomSector, DoomVertex } from '../geometry/doom-geometry';
 
 export class SceneManager {
   private engine: Engine;
@@ -21,8 +23,8 @@ export class SceneManager {
     const scene = new Scene(this.engine);
 
     // Create camera
-    const camera = new FreeCamera('camera', new Vector3(0, 2, -5), scene);
-    camera.setTarget(Vector3.Zero());
+    const camera = new FreeCamera('camera', new Vector3(0, 5, -10), scene);
+    camera.setTarget(new Vector3(0, 2, 0));
     // Attach camera controls to canvas
     const canvas = this.engine.getRenderingCanvas();
     if (canvas) {
@@ -33,18 +35,36 @@ export class SceneManager {
     const light = new HemisphericLight('light', new Vector3(0, 1, 0), scene);
     light.intensity = 0.7;
 
-    // Create simple ground plane
+    // Define a simple square sector
+    const vertices: DoomVertex[] = [
+      { id: 'v1', position: new Vector2(-5, -5) },
+      { id: 'v2', position: new Vector2(5, -5) },
+      { id: 'v3', position: new Vector2(5, 5) },
+      { id: 'v4', position: new Vector2(-5, 5) },
+    ];
+
+    const _sector: DoomSector = {
+      id: 's1',
+      floorHeight: 0,
+      ceilingHeight: 4,
+      floorTexture: 'FLOOR1',
+      ceilingTexture: 'CEIL1',
+      lightLevel: 200,
+      vertices: vertices,
+      lineDefs: [], // Will be populated later
+      neighbors: [],
+      // Bounding box and other data will be calculated by SectorGeometry
+      boundingBox: { min: new Vector2(0, 0), max: new Vector2(0, 0) },
+      meshId: 'sector_s1',
+    };
+
+    // TODO: In the next step, we will use SectorGeometry to create the mesh from `sector` data.
+    // For now, let's keep the ground plane to have something to see.
+    console.log('Defined test sector:', _sector); // Temporary log to avoid unused variable error
     const ground = MeshBuilder.CreateGround('ground', { width: 10, height: 10 }, scene);
     const groundMaterial = new StandardMaterial('groundMaterial', scene);
     groundMaterial.diffuseColor = new Color3(0.4, 0.4, 0.4);
     ground.material = groundMaterial;
-
-    // Create a simple wall for testing
-    const wall = MeshBuilder.CreateBox('wall', { width: 10, height: 3, depth: 0.5 }, scene);
-    wall.position = new Vector3(0, 1.5, 3);
-    const wallMaterial = new StandardMaterial('wallMaterial', scene);
-    wallMaterial.diffuseColor = new Color3(0.6, 0.6, 0.8);
-    wall.material = wallMaterial;
 
     this.currentScene = scene;
     return scene;

--- a/packages/engine/src/geometry/__tests__/sector-geometry.test.ts
+++ b/packages/engine/src/geometry/__tests__/sector-geometry.test.ts
@@ -242,41 +242,30 @@ describe('SectorGeometry', () => {
   });
 
   describe('triangulation', () => {
-    it('should generate valid triangulation data', () => {
-      const result = geometry.triangulate();
-
+    it('should generate valid floor triangulation', () => {
+      const result = geometry.triangulateFloor();
       expect(result.vertices).toBeDefined();
       expect(result.indices).toBeDefined();
       expect(result.uvs).toBeDefined();
-
-      // Should have floor and ceiling vertices
-      expect(result.vertices.length).toBe(8); // 4 floor + 4 ceiling
-
-      // Should have proper UV coordinates
-      expect(result.uvs.length).toBe(8);
-
-      // Should have triangles for floor and ceiling
-      expect(result.indices.length).toBe(12); // 2 triangles * 3 vertices * 2 surfaces
+      expect(result.vertices.length).toBe(4);
+      expect(result.indices.length).toBe(6); // 2 triangles
+      // Check that all vertices are at floor height
+      for (const v of result.vertices) {
+        expect(v.y).toBe(mockSector.floorHeight);
+      }
     });
 
-    it('should cache triangulation results', () => {
-      const result1 = geometry.triangulate();
-      const result2 = geometry.triangulate();
-
-      // Should return same reference (cached)
-      expect(result1).toBe(result2);
-    });
-
-    it('should invalidate cache when geometry changes', () => {
-      const result1 = geometry.triangulate();
-
-      // Invalidate cache
-      geometry.invalidateCache();
-
-      const result2 = geometry.triangulate();
-
-      // Should return different reference (recalculated)
-      expect(result1).not.toBe(result2);
+    it('should generate valid ceiling triangulation', () => {
+      const result = geometry.triangulateCeiling();
+      expect(result.vertices).toBeDefined();
+      expect(result.indices).toBeDefined();
+      expect(result.uvs).toBeDefined();
+      expect(result.vertices.length).toBe(4);
+      expect(result.indices.length).toBe(6); // 2 triangles
+      // Check that all vertices are at ceiling height
+      for (const v of result.vertices) {
+        expect(v.y).toBe(mockSector.ceilingHeight);
+      }
     });
   });
 
@@ -284,7 +273,6 @@ describe('SectorGeometry', () => {
     it('should invalidate all caches', () => {
       // Force cache creation
       geometry.boundingBox;
-      geometry.triangulate();
 
       // Should not throw
       expect(() => geometry.invalidateCache()).not.toThrow();

--- a/packages/engine/src/geometry/sector-geometry.ts
+++ b/packages/engine/src/geometry/sector-geometry.ts
@@ -8,7 +8,6 @@ import type { DoomLineDef, DoomSector, GeometryBounds, TriangulationResult } fro
 export class SectorGeometry {
   private sector: DoomSector;
   private _boundingBox?: GeometryBounds | undefined;
-  private _triangulationCache?: TriangulationResult | undefined;
 
   constructor(sector: DoomSector) {
     this.sector = sector;
@@ -43,7 +42,7 @@ export class SectorGeometry {
    * Calculates and caches the 2D bounding box of the sector
    */
   private calculateBoundingBox(): void {
-    // Note: validateSector() ensures we have at least 3 vertices, so no empty checks are needed.
+    // biome-ignore lint/style/noNonNullAssertion: validateSector ensures at least 3 vertices.
     const firstVertex = this.sector.vertices[0]!;
 
     let minX = firstVertex.position.x;
@@ -52,6 +51,7 @@ export class SectorGeometry {
     let maxY = minY;
 
     for (let i = 1; i < this.sector.vertices.length; i++) {
+      // biome-ignore lint/style/noNonNullAssertion: Loop bounds are checked.
       const vertex = this.sector.vertices[i]!;
       minX = Math.min(minX, vertex.position.x);
       maxX = Math.max(maxX, vertex.position.x);
@@ -76,25 +76,25 @@ export class SectorGeometry {
     if (!this._boundingBox) {
       this.calculateBoundingBox();
     }
-    return this._boundingBox as GeometryBounds;
+    // biome-ignore lint/style/noNonNullAssertion: calculateBoundingBox is guaranteed to set this property.
+    return this._boundingBox!;
   }
 
   /**
    * Calculates the area of the sector using the shoelace formula
    */
   get area(): number {
-    // Gracefully handle edge case: fewer than 3 vertices cannot form a polygon
     const vertices = this.sector.vertices;
     if (vertices.length < 3) {
       return 0;
     }
 
-    // Note: validateSector() ensures at least 3 vertices.
     let area = 0;
-
     for (let i = 0; i < vertices.length; i++) {
       const j = (i + 1) % vertices.length;
+      // biome-ignore lint/style/noNonNullAssertion: Length is checked above.
       const vi = vertices[i]!;
+      // biome-ignore lint/style/noNonNullAssertion: Length is checked above.
       const vj = vertices[j]!;
       area += vi.position.x * vj.position.y;
       area -= vj.position.x * vi.position.y;
@@ -107,15 +107,20 @@ export class SectorGeometry {
    * Calculates the centroid (center point) of the sector
    */
   get centroid(): Vector2 {
+    const vertices = this.sector.vertices;
+    if (vertices.length === 0) {
+      return new Vector2(0, 0);
+    }
+
     let sumX = 0;
     let sumY = 0;
 
-    for (const vertex of this.sector.vertices) {
+    for (const vertex of vertices) {
       sumX += vertex.position.x;
       sumY += vertex.position.y;
     }
 
-    return new Vector2(sumX / this.sector.vertices.length, sumY / this.sector.vertices.length);
+    return new Vector2(sumX / vertices.length, sumY / vertices.length);
   }
 
   /**
@@ -123,12 +128,18 @@ export class SectorGeometry {
    * Uses shoelace formula: negative area = clockwise in screen coordinates
    */
   get isClockwise(): boolean {
-    let sum = 0;
     const vertices = this.sector.vertices;
+    if (vertices.length < 3) {
+      return false;
+    }
 
+    let sum = 0;
     for (let i = 0; i < vertices.length; i++) {
+      const j = (i + 1) % vertices.length;
+      // biome-ignore lint/style/noNonNullAssertion: Length is checked above.
       const curr = vertices[i]!;
-      const next = vertices[(i + 1) % vertices.length]!;
+      // biome-ignore lint/style/noNonNullAssertion: Length is checked above.
+      const next = vertices[j]!;
       sum += (next.position.x - curr.position.x) * (next.position.y + curr.position.y);
     }
 
@@ -144,7 +155,6 @@ export class SectorGeometry {
   ensureClockwiseOrder(): void {
     if (!this.isClockwise) {
       this.sector.vertices.reverse();
-      this._triangulationCache = undefined;
     }
   }
 
@@ -155,9 +165,14 @@ export class SectorGeometry {
   containsPoint(point: Vector2): boolean {
     let inside = false;
     const vertices = this.sector.vertices;
+    if (vertices.length < 3) {
+      return false;
+    }
 
     for (let i = 0, j = vertices.length - 1; i < vertices.length; j = i++) {
+      // biome-ignore lint/style/noNonNullAssertion: Length is checked above.
       const vi = vertices[i]!.position;
+      // biome-ignore lint/style/noNonNullAssertion: Length is checked above.
       const vj = vertices[j]!.position;
 
       if (
@@ -172,55 +187,55 @@ export class SectorGeometry {
   }
 
   /**
-   * Triangulates the sector for mesh generation
-   * Uses ear clipping algorithm for simple polygons
+   * Triangulates the sector floor for mesh generation
    */
-  triangulate(): TriangulationResult {
-    if (this._triangulationCache) {
-      return this._triangulationCache;
-    }
-
+  triangulateFloor(): TriangulationResult {
     this.ensureClockwiseOrder();
 
-    // Simple triangulation for convex polygons
-    // For complex polygons, we'll need a more sophisticated algorithm
     const vertices: Vector3[] = [];
     const indices: number[] = [];
     const uvs: Vector2[] = [];
 
-    // Generate floor vertices
     for (const vertex of this.sector.vertices) {
       vertices.push(new Vector3(vertex.position.x, this.sector.floorHeight, vertex.position.y));
-      // Simple UV mapping - can be improved later
       const bounds = this.boundingBox;
       const u = (vertex.position.x - bounds.minX) / (bounds.maxX - bounds.minX);
       const v = (vertex.position.y - bounds.minY) / (bounds.maxY - bounds.minY);
       uvs.push(new Vector2(u, v));
     }
 
-    // Generate ceiling vertices
-    for (const vertex of this.sector.vertices) {
-      vertices.push(new Vector3(vertex.position.x, this.sector.ceilingHeight, vertex.position.y));
-      // Ceiling UVs (flipped for proper texture mapping)
-      const bounds = this.boundingBox;
-      const u = (vertex.position.x - bounds.minX) / (bounds.maxX - bounds.minX);
-      const v = 1 - (vertex.position.y - bounds.minY) / (bounds.maxY - bounds.minY);
-      uvs.push(new Vector2(u, v));
-    }
-
-    // Triangulate floor (counter-clockwise for upward normal)
+    // Triangulate floor (fan triangulation from the first vertex, counter-clockwise for upward normal)
     for (let i = 1; i < this.sector.vertices.length - 1; i++) {
       indices.push(0, i + 1, i);
     }
 
-    // Triangulate ceiling (clockwise for downward normal)
-    const vertexCount = this.sector.vertices.length;
-    for (let i = 1; i < vertexCount - 1; i++) {
-      indices.push(vertexCount, vertexCount + i, vertexCount + i + 1);
+    return { vertices, indices, uvs };
+  }
+
+  /**
+   * Triangulates the sector ceiling for mesh generation
+   */
+  triangulateCeiling(): TriangulationResult {
+    this.ensureClockwiseOrder();
+
+    const vertices: Vector3[] = [];
+    const indices: number[] = [];
+    const uvs: Vector2[] = [];
+
+    for (const vertex of this.sector.vertices) {
+      vertices.push(new Vector3(vertex.position.x, this.sector.ceilingHeight, vertex.position.y));
+      const bounds = this.boundingBox;
+      const u = (vertex.position.x - bounds.minX) / (bounds.maxX - bounds.minX);
+      const v = 1 - (vertex.position.y - bounds.minY) / (bounds.maxY - bounds.minY); // Flipped V for ceiling
+      uvs.push(new Vector2(u, v));
     }
 
-    this._triangulationCache = { vertices, indices, uvs };
-    return this._triangulationCache;
+    // Triangulate ceiling (fan triangulation, clockwise for downward normal)
+    for (let i = 1; i < this.sector.vertices.length - 1; i++) {
+      indices.push(0, i, i + 1);
+    }
+
+    return { vertices, indices, uvs };
   }
 
   /**
@@ -285,7 +300,6 @@ export class SectorGeometry {
    */
   invalidateCache(): void {
     this._boundingBox = undefined;
-    this._triangulationCache = undefined;
   }
 
   /**


### PR DESCRIPTION
### Summary

This PR implements the foundational logic for rendering a single, hard-coded DOOM-like sector. It replaces the previous generic test scene with the actual floor and ceiling geometry generated from sector data.

### Changes

-   **`SectorGeometry` Refactoring:** The `triangulate()` method has been split into `triangulateFloor()` and `triangulateCeiling()` to allow for separate mesh generation and material application. The obsolete triangulation cache has been removed.
-   **`SceneManager` Update:** The scene manager now defines a hard-coded square sector and uses `SectorGeometry` to generate and render two distinct meshes for the floor and ceiling.
-   **Materials:** Basic `StandardMaterial`s with different colors are applied to the floor and ceiling to make them visible.
-   **Tests:** The tests for `SectorGeometry` have been updated to reflect the refactoring, ensuring the new triangulation methods are covered.

### How to Test

1.  Run the `web` application (`pnpm dev`).
2.  Observe the rendered scene. You should see a grey floor and a blue ceiling, forming a simple square room.
3.  The camera is positioned to view the scene.

This PR directly addresses the first part of the "Géométrie DOOM" task in Phase 1 of the development plan.