### PR TITLE
feat(engine): Render sector walls

### DIFF
--- a/packages/engine/src/core/scene-manager.ts
+++ b/packages/engine/src/core/scene-manager.ts
@@ -221,6 +221,23 @@ export class SceneManager {
     ceilingMaterial.diffuseColor = new Color3(0.2, 0.2, 0.8);
     ceilingMesh.material = ceilingMaterial;
 
+    // Create wall meshes
+    for (const lineDef of sector.lineDefs) {
+      const wallTriangulation = sectorGeometry.generateWallGeometry(lineDef);
+      if (wallTriangulation) {
+        const wallMesh = new Mesh(`${lineDef.id}_wall`, scene);
+        const wallVertexData = new VertexData();
+        wallVertexData.positions = wallTriangulation.vertices.flatMap((v) => [v.x, v.y, v.z]);
+        wallVertexData.indices = wallTriangulation.indices;
+        wallVertexData.uvs = wallTriangulation.uvs.flatMap((v) => [v.x, v.y]);
+        wallVertexData.applyToMesh(wallMesh);
+
+        const wallMaterial = new StandardMaterial(`${lineDef.id}_wall_mat`, scene);
+        wallMaterial.diffuseColor = new Color3(0.8, 0.2, 0.2); // Red walls
+        wallMesh.material = wallMaterial;
+      }
+    }
+
     this.currentScene = scene;
     return scene;
   }

--- a/packages/engine/src/core/scene-manager.ts
+++ b/packages/engine/src/core/scene-manager.ts
@@ -25,8 +25,8 @@ export class SceneManager {
     const scene = new Scene(this.engine);
 
     // Create camera
-    const camera = new FreeCamera('camera', new Vector3(0, 5, -10), scene);
-    camera.setTarget(new Vector3(0, 2, 0));
+    const camera = new FreeCamera('camera', new Vector3(0, 2, 0), scene);
+    camera.setTarget(new Vector3(0, 2, 1));
     // Attach camera controls to canvas
     const canvas = this.engine.getRenderingCanvas();
     if (canvas) {
@@ -205,7 +205,8 @@ export class SceneManager {
     floorVertexData.applyToMesh(floorMesh);
 
     const floorMaterial = new StandardMaterial(`${sector.id}_floor_mat`, scene);
-    floorMaterial.diffuseColor = new Color3(0.5, 0.5, 0.5);
+    floorMaterial.diffuseColor = new Color3(1, 0, 0);
+    floorMaterial.emissiveColor = new Color3(1, 0, 0);
     floorMesh.material = floorMaterial;
 
     // Create ceiling mesh
@@ -218,7 +219,8 @@ export class SceneManager {
     ceilingVertexData.applyToMesh(ceilingMesh);
 
     const ceilingMaterial = new StandardMaterial(`${sector.id}_ceiling_mat`, scene);
-    ceilingMaterial.diffuseColor = new Color3(0.2, 0.2, 0.8);
+    ceilingMaterial.diffuseColor = new Color3(0, 1, 0);
+    ceilingMaterial.emissiveColor = new Color3(0, 1, 0);
     ceilingMesh.material = ceilingMaterial;
 
     // Create wall meshes
@@ -233,7 +235,8 @@ export class SceneManager {
         wallVertexData.applyToMesh(wallMesh);
 
         const wallMaterial = new StandardMaterial(`${lineDef.id}_wall_mat`, scene);
-        wallMaterial.diffuseColor = new Color3(0.8, 0.2, 0.2); // Red walls
+        wallMaterial.diffuseColor = new Color3(0, 0, 1); // Blue walls
+        wallMaterial.emissiveColor = new Color3(0, 0, 1); // Make walls self-illuminating
         wallMesh.material = wallMaterial;
       }
     }

--- a/packages/engine/src/core/scene-manager.ts
+++ b/packages/engine/src/core/scene-manager.ts
@@ -61,14 +61,10 @@ export class SceneManager {
     };
 
     // Define the walls (LineDefs) of the sector
-    const v1 = vertices[0];
-    const v2 = vertices[1];
-    const v3 = vertices[2];
-    const v4 = vertices[3];
-
-    if (!v1 || !v2 || !v3 || !v4) {
-      throw new Error('Hard-coded vertices are missing. This should not happen.');
-    }
+    const v1 = vertices[0]!;
+    const v2 = vertices[1]!;
+    const v3 = vertices[2]!;
+    const v4 = vertices[3]!;
 
     // Note: A circular dependency exists where LineDefs need a Sector and vice-versa.
     // We define the sector first, then the linedefs, then assign them back to the sector.

--- a/packages/engine/src/core/scene-manager.ts
+++ b/packages/engine/src/core/scene-manager.ts
@@ -10,7 +10,7 @@ import {
   Vector3,
   VertexData,
 } from '@babylonjs/core';
-import type { DoomSector, DoomVertex } from '../geometry/doom-geometry';
+import type { DoomLineDef, DoomSector, DoomVertex } from '../geometry/doom-geometry';
 import { SectorGeometry } from '../geometry/sector-geometry';
 
 export class SceneManager {
@@ -59,6 +59,142 @@ export class SceneManager {
       boundingBox: { min: new Vector2(0, 0), max: new Vector2(0, 0) },
       meshId: 'sector_s1',
     };
+
+    // Define the walls (LineDefs) of the sector
+    const v1 = vertices[0];
+    const v2 = vertices[1];
+    const v3 = vertices[2];
+    const v4 = vertices[3];
+
+    if (!v1 || !v2 || !v3 || !v4) {
+      throw new Error('Hard-coded vertices are missing. This should not happen.');
+    }
+
+    // Note: A circular dependency exists where LineDefs need a Sector and vice-versa.
+    // We define the sector first, then the linedefs, then assign them back to the sector.
+    const lineDefs: DoomLineDef[] = [
+      {
+        id: 'l1',
+        startVertex: v1,
+        endVertex: v2,
+        flags: {
+          blocking: true,
+          twoSided: false,
+          dontDraw: false,
+          mapped: true,
+          soundBlock: false,
+          secret: false,
+          lowerUnpegged: false,
+          upperUnpegged: false,
+          blockMonsters: true,
+        },
+        frontSide: {
+          id: 's1_1',
+          sector: sector,
+          textureMiddle: 'WALL1',
+          textureUpper: '-',
+          textureLower: '-',
+          offsetX: 0,
+          offsetY: 0,
+          needsUpperTexture: false,
+          needsLowerTexture: false,
+          needsMiddleTexture: true,
+        },
+        length: 10,
+        normal: new Vector2(0, 1),
+      },
+      {
+        id: 'l2',
+        startVertex: v2,
+        endVertex: v3,
+        flags: {
+          blocking: true,
+          twoSided: false,
+          dontDraw: false,
+          mapped: true,
+          soundBlock: false,
+          secret: false,
+          lowerUnpegged: false,
+          upperUnpegged: false,
+          blockMonsters: true,
+        },
+        frontSide: {
+          id: 's1_2',
+          sector: sector,
+          textureMiddle: 'WALL1',
+          textureUpper: '-',
+          textureLower: '-',
+          offsetX: 0,
+          offsetY: 0,
+          needsUpperTexture: false,
+          needsLowerTexture: false,
+          needsMiddleTexture: true,
+        },
+        length: 10,
+        normal: new Vector2(-1, 0),
+      },
+      {
+        id: 'l3',
+        startVertex: v3,
+        endVertex: v4,
+        flags: {
+          blocking: true,
+          twoSided: false,
+          dontDraw: false,
+          mapped: true,
+          soundBlock: false,
+          secret: false,
+          lowerUnpegged: false,
+          upperUnpegged: false,
+          blockMonsters: true,
+        },
+        frontSide: {
+          id: 's1_3',
+          sector: sector,
+          textureMiddle: 'WALL1',
+          textureUpper: '-',
+          textureLower: '-',
+          offsetX: 0,
+          offsetY: 0,
+          needsUpperTexture: false,
+          needsLowerTexture: false,
+          needsMiddleTexture: true,
+        },
+        length: 10,
+        normal: new Vector2(0, -1),
+      },
+      {
+        id: 'l4',
+        startVertex: v4,
+        endVertex: v1,
+        flags: {
+          blocking: true,
+          twoSided: false,
+          dontDraw: false,
+          mapped: true,
+          soundBlock: false,
+          secret: false,
+          lowerUnpegged: false,
+          upperUnpegged: false,
+          blockMonsters: true,
+        },
+        frontSide: {
+          id: 's1_4',
+          sector: sector,
+          textureMiddle: 'WALL1',
+          textureUpper: '-',
+          textureLower: '-',
+          offsetX: 0,
+          offsetY: 0,
+          needsUpperTexture: false,
+          needsLowerTexture: false,
+          needsMiddleTexture: true,
+        },
+        length: 10,
+        normal: new Vector2(1, 0),
+      },
+    ];
+    sector.lineDefs = lineDefs;
 
     // Create geometry from the sector data
     const sectorGeometry = new SectorGeometry(sector);

--- a/packages/engine/src/geometry/__tests__/sector-geometry.test.ts
+++ b/packages/engine/src/geometry/__tests__/sector-geometry.test.ts
@@ -337,4 +337,98 @@ describe('SectorGeometry', () => {
       expect(collinearGeometry.area).toBe(0);
     });
   });
+
+  describe('wall geometry generation', () => {
+    it('should generate valid full wall geometry for single-sided linedef', () => {
+      const lineDef = {
+        id: 'test-line',
+        startVertex: mockSector.vertices[0],
+        endVertex: mockSector.vertices[1],
+        flags: { blocking: true, twoSided: false },
+        frontSide: {
+          id: 'test-side',
+          sector: mockSector,
+          textureMiddle: 'WALL1',
+          textureUpper: '-',
+          textureLower: '-',
+          offsetX: 0,
+          offsetY: 0,
+          needsUpperTexture: false,
+          needsLowerTexture: false,
+          needsMiddleTexture: true,
+        },
+        length: 100, // Distance between (0,0) and (100,0)
+        normal: new Vector2(0, 1),
+      };
+
+      const result = geometry.generateWallGeometry(lineDef);
+      expect(result).toBeDefined();
+      expect(result?.vertices).toBeDefined();
+      expect(result?.indices).toBeDefined();
+      expect(result?.uvs).toBeDefined();
+
+      // A full wall is a quad, so 4 vertices and 6 indices (2 triangles)
+      expect(result?.vertices.length).toBe(4);
+      expect(result?.indices.length).toBe(6);
+      expect(result?.uvs.length).toBe(4);
+
+      // Check vertex positions (bottom-left, bottom-right, top-right, top-left)
+      expect(result?.vertices[0].x).toBe(0);
+      expect(result?.vertices[0].y).toBe(mockSector.floorHeight);
+      expect(result?.vertices[0].z).toBe(0);
+
+      expect(result?.vertices[1].x).toBe(100);
+      expect(result?.vertices[1].y).toBe(mockSector.floorHeight);
+      expect(result?.vertices[1].z).toBe(0);
+
+      expect(result?.vertices[2].x).toBe(100);
+      expect(result?.vertices[2].y).toBe(mockSector.ceilingHeight);
+      expect(result?.vertices[2].z).toBe(0);
+
+      expect(result?.vertices[3].x).toBe(0);
+      expect(result?.vertices[3].y).toBe(mockSector.ceilingHeight);
+      expect(result?.vertices[3].z).toBe(0);
+    });
+
+    it('should return null for two-sided linedef if partial walls not implemented', () => {
+      const lineDef = {
+        id: 'test-line-two-sided',
+        startVertex: mockSector.vertices[0],
+        endVertex: mockSector.vertices[1],
+        flags: { blocking: true, twoSided: true }, // Two-sided
+        frontSide: {
+          id: 'test-side-front',
+          sector: mockSector,
+          textureMiddle: 'WALL1',
+          textureUpper: '-',
+          textureLower: '-',
+          offsetX: 0,
+          offsetY: 0,
+          needsUpperTexture: false,
+          needsLowerTexture: false,
+          needsMiddleTexture: true,
+        },
+        backSide: {
+          // Minimal back side
+          id: 'test-side-back',
+          sector: mockSector,
+          textureMiddle: 'WALL1',
+          textureUpper: '-',
+          textureLower: '-',
+          offsetX: 0,
+          offsetY: 0,
+          needsUpperTexture: false,
+          needsLowerTexture: false,
+          needsMiddleTexture: true,
+        },
+        length: 100,
+        normal: new Vector2(0, 1),
+      };
+
+      // Expect it to throw an error because generatePartialWalls is not implemented
+      expect(() => geometry.generateWallGeometry(lineDef)).toThrow(
+        'TODO: generatePartialWalls is not implemented'
+      );
+    });
+  });
 });


### PR DESCRIPTION
### Summary

This PR implements the generation and rendering of wall meshes for the hard-coded test sector.

### Changes

-   **SceneManager Update:** The scene manager now defines LineDef data structures for the four walls of the square sector.
-   **Wall Geometry Generation:** It iterates through these LineDefs, uses SectorGeometry.generateWallGeometry() to obtain the mesh data, and creates a Babylon.js Mesh for each wall.
-   **Materials:** RGB debugging colors are applied to differentiate sector elements (red floor, green ceiling, blue walls).
-   **Tests:** A new test has been added to sector-geometry.test.ts to verify the generateWallGeometry method.

### How to Test

1.  Run the web application (pnpm dev).
2.  Observe the rendered scene. You should now see a **red floor, green ceiling, and four blue walls** forming a simple square room.
3.  The pure RGB colors are used for debugging purposes to easily identify different sector elements.

### Technical Notes

The current color scheme uses pure RGB values for debugging:
- Floor: Red (1,0,0) 
- Ceiling: Green (0,1,0)
- Walls: Blue (0,0,1)

This PR continues the work on "Géométrie DOOM" in Phase 1 of the development plan.