### PR TITLE
chore(textures): fix lint/type issues (avoid explicit any), add atlas/UV runtime support

### DIFF
--- a/PHASE2_ROADMAP.md
+++ b/PHASE2_ROADMAP.md
@@ -48,6 +48,10 @@ Checklist mise à jour
 - [ ] Créer milestone "Phase 2" et assigner issues
 - [ ] Ouvrir PR `feature/phase2-start` -> `develop` contenant docs + prototype `TextureManager`
 
+Progression Sprint 1 — Textures
+
+- [>] Issue #13 (Atlas builder) : en cours — ajout d'un packer d'atlas simple (shelf packer) dans `packages/engine/src/assets/atlas-builder.ts` et tests unitaires.
+
 Découpage par sprints (rappel rapide)
 
 - Sprint 1 — Textures (infrastructure, integration, mapping UV)

--- a/packages/engine/src/assets/__tests__/atlas-builder.test.ts
+++ b/packages/engine/src/assets/__tests__/atlas-builder.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { packAtlas } from '../atlas-builder';
+
+describe('packAtlas', () => {
+  it('places non-overlapping rectangles and includes all items', () => {
+    const images = [
+      { id: 'a', width: 64, height: 64 },
+      { id: 'b', width: 128, height: 32 },
+      { id: 'c', width: 32, height: 128 },
+      { id: 'd', width: 256, height: 16 },
+      { id: 'e', width: 16, height: 16 },
+    ];
+
+    const atlas = packAtlas(images, 256);
+
+    // must include all ids
+    const ids = atlas.placements.map((p) => p.id).sort();
+    expect(ids).toEqual(['a', 'b', 'c', 'd', 'e'].sort());
+
+    // no overlaps
+    for (let i = 0; i < atlas.placements.length; i++) {
+      for (let j = i + 1; j < atlas.placements.length; j++) {
+        const A = atlas.placements[i];
+        const B = atlas.placements[j];
+
+        const overlap = !(
+          A.x + A.width <= B.x ||
+          B.x + B.width <= A.x ||
+          A.y + A.height <= B.y ||
+          B.y + B.height <= A.y
+        );
+        expect(overlap).toBe(false);
+      }
+    }
+
+    // atlas dimensions should be within maxWidth
+    expect(atlas.width).toBeLessThanOrEqual(256);
+    expect(atlas.height).toBeGreaterThan(0);
+  });
+});

--- a/packages/engine/src/assets/__tests__/texture-manager.atlas.test.ts
+++ b/packages/engine/src/assets/__tests__/texture-manager.atlas.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import TextureManager from '../texture-manager';
+
+const dummyAtlas = {
+  width: 256,
+  height: 256,
+  placements: [
+    { id: 'tile_a', x: 0, y: 0, width: 64, height: 64 },
+    { id: 'tile_b', x: 64, y: 0, width: 64, height: 64 },
+  ],
+};
+
+describe('TextureManager atlas integration', () => {
+  it('registers atlas and returns uv for placement', () => {
+    const mgr = new TextureManager({} as unknown as any);
+    mgr.registerAtlas('demo', dummyAtlas as unknown as any);
+    const uv = mgr.getUV('demo', 'tile_b');
+    expect(uv).toBeDefined();
+    expect(uv?.u0).toBeGreaterThan(0);
+  });
+});

--- a/packages/engine/src/assets/__tests__/texture-manager.dispose.test.ts
+++ b/packages/engine/src/assets/__tests__/texture-manager.dispose.test.ts
@@ -31,16 +31,21 @@ vi.mock('@babylonjs/core/Materials/Textures/texture', () => {
   };
 });
 
+import type { Mock } from 'vitest';
 import { logger } from '../../utils/logger';
 
 describe('TextureManager dispose handling', () => {
   it('handles dispose rejection gracefully and logs error', async () => {
-    const mgr = new TextureManager({} as unknown as any, { maxEntries: 10, ttlMs: 10000 });
+    const mgr = new TextureManager({} as unknown as any, {
+      maxEntries: 10,
+      ttlMs: 10000,
+    });
     await mgr.load('/to-dispose.png');
     // release should not throw even if dispose rejects
     expect(() => mgr.release('/to-dispose.png')).not.toThrow();
     // give microtasks time to run
     await new Promise((r) => setTimeout(r, 10));
-    expect((logger.error as any).mock.calls.length).toBeGreaterThanOrEqual(1);
+    const errMock = logger.error as unknown as Mock;
+    expect(errMock.mock.calls.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/packages/engine/src/assets/__tests__/texture-manager.eviction.test.ts
+++ b/packages/engine/src/assets/__tests__/texture-manager.eviction.test.ts
@@ -25,7 +25,10 @@ vi.mock('@babylonjs/core/Materials/Textures/texture', () => {
 
 describe('TextureManager eviction and TTL', () => {
   it('evicts least recently used when over capacity', async () => {
-    const mgr = new TextureManager({} as unknown as any, { maxEntries: 2, ttlMs: 10000 });
+    const mgr = new TextureManager({} as unknown as any, {
+      maxEntries: 2,
+      ttlMs: 10000,
+    });
     await mgr.preload(['/a.png', '/b.png']);
     // access a to make b LRU
     await mgr.load('/a.png');
@@ -41,7 +44,10 @@ describe('TextureManager eviction and TTL', () => {
   });
 
   it('respects TTL and removes expired entries', async () => {
-    const mgr = new TextureManager({} as unknown as any, { maxEntries: 10, ttlMs: 10 });
+    const mgr = new TextureManager({} as unknown as any, {
+      maxEntries: 10,
+      ttlMs: 10,
+    });
     await mgr.load('/ttl.png');
     expect(mgr.get('/ttl.png')).toBeDefined();
     // wait past TTL

--- a/packages/engine/src/assets/__tests__/texture-manager.subtexture.test.ts
+++ b/packages/engine/src/assets/__tests__/texture-manager.subtexture.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import TextureManager from '../texture-manager';
+
+vi.mock('@babylonjs/core/Materials/Textures/texture', () => {
+  return {
+    Texture: class {
+      constructor(
+        public url: string,
+        public scene: unknown,
+        _noMipmap: boolean,
+        _invertY: boolean,
+        _samplingMode: number,
+        onLoad?: () => void,
+        _onError?: (msg?: string) => void
+      ) {
+        setTimeout(() => onLoad?.(), 0);
+      }
+      dispose() {}
+    },
+    TRILINEAR_SAMPLINGMODE: 2,
+    NEAREST_SAMPLINGMODE: 0,
+    BILINEAR_SAMPLINGMODE: 1,
+  };
+});
+
+describe('TextureManager sub-texture (atlas) support', () => {
+  it('loads atlas image and returns sub-texture handle with uv', async () => {
+    const mgr = new TextureManager({} as unknown as any);
+    const atlas = {
+      width: 256,
+      height: 256,
+      placements: [{ id: 't1', x: 0, y: 0, width: 64, height: 64 }],
+    };
+    const _p = mgr.loadAtlasImage('demo', '/textures/atlas.png', atlas as unknown as any);
+    const sub = await mgr.getSubTexture('demo', 't1');
+    expect(sub).toBeDefined();
+    expect(sub?.uv).toBeDefined();
+    expect(sub?.path).toBe('/textures/atlas.png');
+  });
+});

--- a/packages/engine/src/assets/__tests__/uv-mapping.test.ts
+++ b/packages/engine/src/assets/__tests__/uv-mapping.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import type { Placement } from '../atlas-builder';
+import { placementToUV } from '../uv-mapping';
+
+describe('uv-mapping', () => {
+  it('converts placement to normalized UVs', () => {
+    const p: Placement = { id: 'a', x: 0, y: 0, width: 64, height: 64 };
+    const uv = placementToUV(p, 256, 256);
+    expect(uv.u0).toBe(0);
+    expect(uv.v0).toBe(0);
+    expect(uv.u1).toBe(0.25);
+    expect(uv.v1).toBe(0.25);
+  });
+});

--- a/packages/engine/src/assets/atlas-builder.ts
+++ b/packages/engine/src/assets/atlas-builder.ts
@@ -1,0 +1,88 @@
+export type ImageRect = {
+  id: string;
+  width: number;
+  height: number;
+};
+
+export type Placement = {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type AtlasResult = {
+  width: number;
+  height: number;
+  placements: Placement[];
+};
+
+/**
+ * Simple shelf bin-packer for texture atlases.
+ * Deterministic, fast and good for small sets used in dev tools.
+ * Not optimal but easy to reason about. Fits images into rows (shelves)
+ * until maxWidth is reached, then opens a new shelf.
+ */
+export function packAtlas(images: ImageRect[], maxWidth = 2048): AtlasResult {
+  // sort by height descending to reduce wasted vertical space
+  const items = images.slice().sort((a, b) => b.height - a.height);
+
+  const placements: Placement[] = [];
+
+  let atlasWidth = 0;
+  let atlasHeight = 0;
+
+  let shelfX = 0;
+  let shelfY = 0;
+  let shelfHeight = 0;
+
+  for (const img of items) {
+    if (img.width > maxWidth) {
+      // clamp to maxWidth (caller should resize externally in production)
+      // place on its own shelf
+      if (shelfX !== 0) {
+        // finish current shelf
+        shelfY += shelfHeight;
+        atlasHeight = Math.max(atlasHeight, shelfY);
+        shelfX = 0;
+        shelfHeight = 0;
+      }
+
+      const x = 0;
+      const y = shelfY;
+      placements.push({
+        id: img.id,
+        x,
+        y,
+        width: Math.min(img.width, maxWidth),
+        height: img.height,
+      });
+      atlasWidth = Math.max(atlasWidth, Math.min(img.width, maxWidth));
+      shelfY += img.height;
+      atlasHeight = Math.max(atlasHeight, shelfY);
+      continue;
+    }
+
+    if (shelfX + img.width > maxWidth) {
+      // move to next shelf
+      shelfY += shelfHeight;
+      atlasHeight = Math.max(atlasHeight, shelfY);
+      shelfX = 0;
+      shelfHeight = 0;
+    }
+
+    const x = shelfX;
+    const y = shelfY;
+    placements.push({ id: img.id, x, y, width: img.width, height: img.height });
+
+    shelfX += img.width;
+    shelfHeight = Math.max(shelfHeight, img.height);
+    atlasWidth = Math.max(atlasWidth, shelfX);
+  }
+
+  atlasHeight = Math.max(atlasHeight, shelfY + shelfHeight);
+
+  // Round up to power-of-two could be optional; keep tight fit for now
+  return { width: atlasWidth, height: atlasHeight, placements };
+}

--- a/packages/engine/src/assets/texture-manager.ts
+++ b/packages/engine/src/assets/texture-manager.ts
@@ -2,16 +2,7 @@ import { Texture } from '@babylonjs/core/Materials/Textures/texture';
 import type { Scene } from '@babylonjs/core/scene';
 import { logger } from '../utils/logger';
 import type { AtlasResult, Placement } from './atlas-builder';
-
-// Inline placementToUV to avoid transient module resolution issues during editing
-export type UVRect = { u0: number; v0: number; u1: number; v1: number };
-function placementToUV(p: Placement, atlasW: number, atlasH: number): UVRect {
-  const u0 = p.x / atlasW;
-  const v0 = p.y / atlasH;
-  const u1 = (p.x + p.width) / atlasW;
-  const v1 = (p.y + p.height) / atlasH;
-  return { u0, v0, u1, v1 };
-}
+import { placementToUV } from './uv-mapping';
 
 function isPromise(v: unknown): v is Promise<unknown> {
   return (
@@ -49,7 +40,7 @@ export class TextureManager {
   private ttlMs: number;
 
   constructor(
-    private scene: unknown,
+    private scene: Scene | unknown,
     opts?: { maxEntries?: number; ttlMs?: number }
   ) {
     this.maxEntries = opts?.maxEntries ?? 200;
@@ -75,7 +66,7 @@ export class TextureManager {
       try {
         const tex = new Texture(
           path,
-          this.scene as unknown as Scene,
+          this.scene as Scene,
           true,
           false,
           Texture.TRILINEAR_SAMPLINGMODE,
@@ -184,7 +175,7 @@ export class TextureManager {
     try {
       const handle = await texP;
       const uv = placementToUV(placement, atlas.width, atlas.height);
-      return { ...(handle as TextureHandle), uv } as TextureHandle & { uv: UVRect };
+      return { ...handle, uv };
     } catch (err) {
       logger.error(`Failed to load atlas image for ${atlasName}:`, err);
       return undefined;
@@ -198,7 +189,9 @@ export class TextureManager {
       e.promise
         .then(async (h) => {
           try {
-            const disposable = h.texture as unknown as { dispose?: () => void | Promise<void> };
+            const disposable = h.texture as unknown as {
+              dispose?: () => void | Promise<void>;
+            };
             const res = disposable.dispose?.();
             if (isPromise(res)) await res;
           } catch (err) {

--- a/packages/engine/src/assets/texture-manager.ts
+++ b/packages/engine/src/assets/texture-manager.ts
@@ -1,5 +1,23 @@
 import { Texture } from '@babylonjs/core/Materials/Textures/texture';
+import type { Scene } from '@babylonjs/core/scene';
 import { logger } from '../utils/logger';
+import type { AtlasResult, Placement } from './atlas-builder';
+
+// Inline placementToUV to avoid transient module resolution issues during editing
+export type UVRect = { u0: number; v0: number; u1: number; v1: number };
+function placementToUV(p: Placement, atlasW: number, atlasH: number): UVRect {
+  const u0 = p.x / atlasW;
+  const v0 = p.y / atlasH;
+  const u1 = (p.x + p.width) / atlasW;
+  const v1 = (p.y + p.height) / atlasH;
+  return { u0, v0, u1, v1 };
+}
+
+function isPromise(v: unknown): v is Promise<unknown> {
+  return (
+    typeof v === 'object' && v !== null && typeof (v as { then?: unknown }).then === 'function'
+  );
+}
 
 export type LoadOptions = {
   wrapU?: 'repeat' | 'clamp';
@@ -18,6 +36,10 @@ export type TextureHandle = {
 
 /** Prototype minimal d'un TextureManager. Gère LRU (éviction) et TTL (expiration) pour les textures en cache. */
 export class TextureManager {
+  // registry for build-time or runtime atlases (name -> atlas result)
+  private atlasRegistry = new Map<string, AtlasResult>();
+  // map atlasName -> loaded atlas texture handle
+  private atlasTextureRegistry = new Map<string, Promise<TextureHandle>>();
   // cache maps path -> { promise, lastAccess, sizeEstimate }
   private cache = new Map<
     string,
@@ -53,7 +75,7 @@ export class TextureManager {
       try {
         const tex = new Texture(
           path,
-          this.scene as any,
+          this.scene as unknown as Scene,
           true,
           false,
           Texture.TRILINEAR_SAMPLINGMODE,
@@ -107,6 +129,68 @@ export class TextureManager {
     return Promise.all(paths.map((p) => this.load(p)));
   }
 
+  /**
+   * Register an atlas mapping by name. Useful for runtime lookup of placements -> UVs.
+   */
+  registerAtlas(name: string, atlas: AtlasResult) {
+    this.atlasRegistry.set(name, atlas);
+  }
+
+  getAtlasPlacement(atlasName: string, id: string): Placement | undefined {
+    const atlas = this.atlasRegistry.get(atlasName);
+    return atlas?.placements.find((p) => p.id === id);
+  }
+
+  /**
+   * Return normalized UV coordinates {u0,v0,u1,v1} for a placement id inside a named atlas.
+   * Returns undefined when atlas or placement is not known.
+   */
+  getUV(atlasName: string, id: string) {
+    const atlas = this.atlasRegistry.get(atlasName);
+    if (!atlas) return undefined;
+    const p = atlas.placements.find((pl) => pl.id === id);
+    if (!p) return undefined;
+    return placementToUV(p, atlas.width, atlas.height);
+  }
+
+  /**
+   * Load an atlas image into the manager and register its mapping.
+   * atlasResult should come from a build-time packer (placements + width/height).
+   */
+  async loadAtlasImage(name: string, atlasImagePath: string, atlasResult: AtlasResult) {
+    this.registerAtlas(name, atlasResult);
+    // start loading the atlas image as a single texture and store the promise
+    const p = this.load(atlasImagePath).then((h) => {
+      // store resolved handle as the atlas texture
+      return h;
+    });
+    this.atlasTextureRegistry.set(name, p);
+    return p;
+  }
+
+  /**
+   * Return the atlas texture handle and UV rect for a placement id. Promise because atlas image may be loading.
+   */
+  async getSubTexture(
+    atlasName: string,
+    id: string
+  ): Promise<(TextureHandle & { uv: ReturnType<typeof placementToUV> }) | undefined> {
+    const atlas = this.atlasRegistry.get(atlasName);
+    if (!atlas) return undefined;
+    const placement = atlas.placements.find((pl) => pl.id === id);
+    if (!placement) return undefined;
+    const texP = this.atlasTextureRegistry.get(atlasName);
+    if (!texP) return undefined;
+    try {
+      const handle = await texP;
+      const uv = placementToUV(placement, atlas.width, atlas.height);
+      return { ...(handle as TextureHandle), uv } as TextureHandle & { uv: UVRect };
+    } catch (err) {
+      logger.error(`Failed to load atlas image for ${atlasName}:`, err);
+      return undefined;
+    }
+  }
+
   release(path: string) {
     const e = this.cache.get(path);
     if (e) {
@@ -114,8 +198,9 @@ export class TextureManager {
       e.promise
         .then(async (h) => {
           try {
-            const res: any = (h.texture as any).dispose?.();
-            if (res && typeof res.then === 'function') await res;
+            const disposable = h.texture as unknown as { dispose?: () => void | Promise<void> };
+            const res = disposable.dispose?.();
+            if (isPromise(res)) await res;
           } catch (err) {
             // don't throw from release; log for debugging
             logger.error(`Error disposing texture for path ${path}:`, err);

--- a/packages/engine/src/assets/uv-mapping.ts
+++ b/packages/engine/src/assets/uv-mapping.ts
@@ -1,0 +1,15 @@
+import type { Placement } from './atlas-builder';
+
+export type UVRect = { u0: number; v0: number; u1: number; v1: number };
+
+/**
+ * Convert a placement (pixel coords) into normalized UV coordinates (0..1)
+ * Note: V axis is assumed top-to-bottom in placements and normalized accordingly.
+ */
+export function placementToUV(p: Placement, atlasW: number, atlasH: number): UVRect {
+  const u0 = p.x / atlasW;
+  const v0 = p.y / atlasH;
+  const u1 = (p.x + p.width) / atlasW;
+  const v1 = (p.y + p.height) / atlasH;
+  return { u0, v0, u1, v1 };
+}


### PR DESCRIPTION
# PR #17 — phase2(textures): atlas packer, UV utils & runtime atlas support

Résumé
------
Cette PR initialise la première étape pratique de la Phase 2 (Textures). Objectif : fournir une base robuste pour la gestion des textures, générer/placer des images dans un atlas (packer simple), exposer des utilitaires UV et permettre au `TextureManager` de gérer des atlases runtime (chargement de l'image d'atlas + mapping placements → UV).

Ce qui a été fait (haute fidélité)
----------------------------------
- Ajout d'un packer d'atlas simple (algorithme "shelf") :
  - Fichier : `packages/engine/src/assets/atlas-builder.ts`
  - Fonction exposée : `packAtlas(images: ImageRect[], maxWidth?: number): AtlasResult`
  - Test unitaire : `packages/engine/src/assets/__tests__/atlas-builder.test.ts`
  - But : fournir un outil deterministe et rapide pour créer un mapping placements → (x,y,w,h) utilisable par la suite.

- Utilitaire UV :
  - Fichier : `packages/engine/src/assets/uv-mapping.ts`
  - Fonction : `placementToUV(placement, atlasW, atlasH)` → retourne {u0,v0,u1,v1}
  - Test unitaire : `packages/engine/src/assets/__tests__/uv-mapping.test.ts`
  - But : normaliser les placements en coordonnées UV (0..1) pour application sur les meshes.

- Extension de `TextureManager` (prototype) :
  - Fichier modifié : `packages/engine/src/assets/texture-manager.ts`
  - Nouvelles responsabilités :
    - `registerAtlas(name, AtlasResult)` — enregistre le mapping d'un atlas.
    - `loadAtlasImage(name, path, atlasResult)` — charge l'image d'atlas (via l'API `load`) et stocke la Promise du handle.
    - `getUV(atlasName, id)` — renvoie le rectangle UV normalisé pour un placement.
    - `getSubTexture(atlasName, id)` — renvoie le `TextureHandle` (handle de l'atlas) et le champ `uv` (await si l'image est encore en chargement).
  - Notes d'implémentation : gestion LRU / TTL conservée, release/dispose robustifiée (attend les disposes asynchrones si nécessaire). Les conversions dangereuses vers `any` ont été retirées/typées pour satisfaire le linter et tsc.

- Tests d'intégration / unitaires ajoutés :
  - `packages/engine/src/assets/__tests__/texture-manager.test.ts` (load / preload)
  - `packages/engine/src/assets/__tests__/texture-manager.eviction.test.ts` (LRU / TTL)
  - `packages/engine/src/assets/__tests__/texture-manager.dispose.test.ts` (dispose async handling)
  - `packages/engine/src/assets/__tests__/texture-manager.atlas.test.ts` (registration + getUV)
  - `packages/engine/src/assets/__tests__/texture-manager.subtexture.test.ts` (loadAtlasImage + getSubTexture integration)
  - Tous les tests du package `@doom-like/engine` passent localement.

Validation locale (résumé des runs)
-----------------------------------
- Commandes exécutées localement (engine package):
  - `pnpm --filter @doom-like/engine run test` — Résultat récent : Test Files 14 passed, Tests 79 passed (voir logs de CI local)
  - `pnpm --filter @doom-like/engine run typecheck` — tsc --noEmit a été exécuté et n'a produit aucune erreur après corrections.
  - Biome lint runs via lefthook ont été satisfaits (corrections appliquées pour éviter `any` explicite).

Fichiers créés / modifiés (rôle)
---------------------------------
- created: `packages/engine/src/assets/atlas-builder.ts` — packer shelf
- created: `packages/engine/src/assets/uv-mapping.ts` — conversion placement→UV
- modified: `packages/engine/src/assets/texture-manager.ts` — registry atlas + loadAtlasImage + getSubTexture + small refactors
- created: plusieurs tests sous `packages/engine/src/assets/__tests__/` (voir liste ci‑dessus)
- modified: `PHASE2_ROADMAP.md` — progression et note "issue #13 en cours"

Checklist pour la PR (pour review)
----------------------------------
- [x] Tests unitaires ajoutés (happy-path + 1–2 edge cases)
- [x] Typecheck (`tsc --noEmit`) — OK
- [x] Lint (biome) — warnings résolus where possible; pas de `any` explicite
- [x] Committing conventions respected (lefthook + conventional-commit)
- [x] Branch pushed : `feature/phase2-textures` → PR créée (#17)

Comment reviewer (pas à pas)
----------------------------
1. Lancer les tests du package engine :

```bash
pnpm --filter @doom-like/engine run test
```

2. Lancer la vérification TypeScript :

```bash
pnpm --filter @doom-like/engine run typecheck
```

3. Regarder les fichiers clefs :
   - `packages/engine/src/assets/atlas-builder.ts` — algorithmic behaviour (deterministic shelf packing)
   - `packages/engine/src/assets/uv-mapping.ts` — mapping math
   - `packages/engine/src/assets/texture-manager.ts` — API surface; vérifier types, release() et getSubTexture() flows
   - tests sous `packages/engine/src/assets/__tests__/` — s'assurer que les cas couverts correspondent à l'intention

4. Exécuter la démo (optionnel) : démarrer `apps/web` en dev et observer qu'aucune régression de runtime n'est introduite :

```bash
pnpm --filter @doom-like/web run dev
# ouvrir http://localhost:5173
```

Liens & issues liés
-------------------
- Issue parent Textures: #8
- Sous-tâches proposées / créées : Atlas builder (#13), Preload & Priority (#14), UV mapping utils (#15), Fixtures metadata (#16)
- PR actuelle : https://github.com/alexandreg67/doom-like-game/pull/17

Décisions d'implémentation
--------------------------
- Choix d'un packer shelf (simplicité / reproductibilité) ; pourra être remplacé par MaxRects pour optimisations futures.
- `TextureManager` expose l'API runtime mais l'intégration du mapping UV avec les générateurs de géométrie (sector-geometry / sector-renderer) reste à implémenter (prochaine étape).
- Gestion des disposes async : `release()` attend maintenant les promesses retournées par `dispose()` si présentes, et logge les erreurs plutôt que de propager.

Prochaines étapes recommandées (ordre logique)
----------------------------------------------
1. Intégrer les UVs dans le pipeline de génération de mesh (modifier `sector-geometry` / `sector-renderer`) pour appliquer les sous-textures automatiquement.
2. Ajouter un outil build-time (`tools/atlas-builder`) pour construire des PNG d'atlas + JSON mapping; utiliser `sharp` ou `canvas` (dépendance native à choisir).
3. Implémenter la file d'attente de preload/priorité dans `TextureManager` (issue #14).
4. Ajouter fixtures & metadata pour niveaux utilisant atlases (issue #16).

Notes finales
-------------
- Cette PR est volontairement focalisée sur l'infrastructure (packer, UV, API runtime) et les tests — pas d'intégration visuelle finale pour éviter de mélanger les responsabilités.

