### PR TITLE
feat(level/lighting): étendre les balises rouges, corriger blackout et définir test_level_extended par défaut

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,65 +1,73 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta name="description" content="Modern DOOM-like web game built with Babylon.js and WebGPU" />
-  
-  <!-- Security headers -->
-  <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
-  <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
-  
-  <!-- Performance hints -->
-  <link rel="preconnect" href="https://cdn.babylonjs.com" />
-  
-  <title>DOOM-Like Game</title>
-  
-  <!-- Favicon -->
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-</head>
-<body>
-  <div id="app">
-    <header>
-      <h1>DOOM-Like Game</h1>
-      <p>Modern retro FPS powered by Babylon.js & WebGPU</p>
-    </header>
-    
-    <main>
-      <div id="level-selector">
-        <h3>Sélection de niveau</h3>
-        <select id="level-select">
-          <option value="demo_level_phase1">Phase 1 Demo (Default)</option>
-          <option value="test_level_complete">Test Level Complete (3 Rooms)</option>
-          <option value="test_level_extended">Test Level Extended (7 Rooms + Secret)</option>
-        </select>
-        <button id="load-level-btn">Charger niveau</button>
-        <button id="reload-level-btn">Recharger niveau actuel</button>
-      </div>
-      
-      <canvas id="gameCanvas" width="1280" height="720"></canvas>
-      
-      <div id="loading">
-        <h2>Loading...</h2>
-        <div class="spinner"></div>
-        <p>Initializing WebGPU renderer...</p>
-      </div>
-      
-      <div id="error">
-        <!-- Error content will be inserted by JavaScript -->
-      </div>
-    </main>
-    
-    <footer>
-      <div id="controls">
-        <strong>Contrôles AZERTY:</strong> 
-        ZQSD - Mouvement | Espace - Saut | Ctrl - Accroupir | Shift - Course | Souris - Regarder | Clic - Capturer souris
-      </div>
-      <div id="renderer-info">
-        <!-- Renderer info will be inserted by JavaScript -->
-      </div>
-    </footer>
-  </div>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Modern DOOM-like web game built with Babylon.js and WebGPU"
+    />
 
-  <script type="module" src="/src/main.ts"></script>
-</body>
+    <!-- Security headers -->
+    <meta http-equiv="Cross-Origin-Opener-Policy" content="same-origin" />
+    <meta http-equiv="Cross-Origin-Embedder-Policy" content="require-corp" />
+
+    <!-- Performance hints -->
+    <link rel="preconnect" href="https://cdn.babylonjs.com" />
+
+    <title>DOOM-Like Game</title>
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <div id="app">
+      <header>
+        <h1>DOOM-Like Game</h1>
+        <p>Modern retro FPS powered by Babylon.js & WebGPU</p>
+      </header>
+
+      <main>
+        <div id="level-selector">
+          <h3>Sélection de niveau</h3>
+          <select id="level-select">
+            <option value="test_level_extended">
+              Test Level Extended (7 Rooms + Secret) (Default)
+            </option>
+            <option value="test_level_complete">
+              Test Level Complete (3 Rooms)
+            </option>
+            <option value="demo_level_phase1">Phase 1 Demo</option>
+          </select>
+          <button id="load-level-btn">Charger niveau</button>
+          <button id="reload-level-btn">Recharger niveau actuel</button>
+        </div>
+
+        <canvas id="gameCanvas" width="1280" height="720"></canvas>
+
+        <div id="loading">
+          <h2>Loading...</h2>
+          <div class="spinner"></div>
+          <p>Initializing WebGPU renderer...</p>
+        </div>
+
+        <div id="error">
+          <!-- Error content will be inserted by JavaScript -->
+        </div>
+      </main>
+
+      <footer>
+        <div id="controls">
+          <strong>Contrôles AZERTY:</strong>
+          ZQSD - Mouvement | Espace - Saut | Ctrl - Accroupir | Shift - Course |
+          Souris - Regarder | Clic - Capturer souris
+        </div>
+        <div id="renderer-info">
+          <!-- Renderer info will be inserted by JavaScript -->
+        </div>
+      </footer>
+    </div>
+
+    <script type="module" src="/src/main.ts"></script>
+  </body>
 </html>

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -15,7 +15,7 @@ const gameState = {
   playerController: null as PlayerController | null,
   cameraController: null as FPSCameraController | null,
   collisionDetector: null as CollisionDetector | null,
-  currentLevel: 'demo_level_phase1',
+  currentLevel: 'test_level_extended',
   gameRunning: false,
 };
 
@@ -151,7 +151,9 @@ async function loadLevel(levelName: string) {
 
     // For now, just update the collision system and player position
     console.log(
-      `[GAME] Collision geometry loaded with ${levelData.lineDefs.length} lines and ${Array.from(levelData.sectors.values()).length} sectors`
+      `[GAME] Collision geometry loaded with ${
+        levelData.lineDefs.length
+      } lines and ${Array.from(levelData.sectors.values()).length} sectors`
     );
 
     gameState.currentLevel = levelName;
@@ -306,7 +308,9 @@ function setupRendererInfo() {
   const capabilities = gameState.engine.getRenderer().getCapabilities();
 
   rendererInfo.innerHTML = `
-    <p><strong>Renderer:</strong> ${rendererType.toUpperCase()} ${capabilities.supported ? '✅' : '⚠️'}</p>
+    <p><strong>Renderer:</strong> ${rendererType.toUpperCase()} ${
+      capabilities.supported ? '✅' : '⚠️'
+    }</p>
     <p><strong>Version:</strong> Babylon.js ${babylonEngine.version}</p>
     <p><strong>FPS:</strong> <span id="fps">--</span></p>
     <p><strong>Level:</strong> <span id="current-level">${gameState.currentLevel}</span></p>
@@ -346,7 +350,9 @@ function updateDisplayMetrics() {
       .getEntity()
       .components.get('transform') as Transform;
     if (transform) {
-      posElement.textContent = `${transform.x.toFixed(1)}, ${transform.y.toFixed(1)}, ${transform.z.toFixed(1)}`;
+      posElement.textContent = `${transform.x.toFixed(
+        1
+      )}, ${transform.y.toFixed(1)}, ${transform.z.toFixed(1)}`;
     }
   }
 

--- a/docs/LEVEL_CREATION_GUIDE.md
+++ b/docs/LEVEL_CREATION_GUIDE.md
@@ -7,16 +7,19 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
 ## 🚨 Problèmes Typiques Rencontrés
 
 ### 1. **Murs manquants**
+
 - **Symptôme** : Secteurs sans contours visuels complets
 - **Cause** : Secteurs définis sans `lineDefs` pour tous leurs bords
 - **Solution** : Créer des `lineDefs` pour chaque arête de secteur
 
 ### 2. **Collision unidirectionnelle** ✅ CORRIGÉ
+
 - **Symptôme** : Passage possible dans un sens mais pas l'autre
 - **Cause** : Ancienne limitation du système de collision (résolu en v0.1.0)
 - **Solution** : Le système de collision bidirectionnelle est maintenant actif automatiquement
 
 ### 3. **Z-fighting / Clignotement**
+
 - **Symptôme** : Surfaces qui clignotent ou se chevauchent
 - **Cause** : Murs dupliqués ou surfaces à la même profondeur
 - **Solution** : Éviter les doublons, vérifier l'unicité des `lineDefs`
@@ -26,108 +29,121 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
 ### Composants Obligatoires
 
 #### 1. **Vertices (Points)**
+
 ```json
 {
-  "id": "v1",           // Identifiant unique
-  "position": {         // Coordonnées 2D
+  "id": "v1", // Identifiant unique
+  "position": {
+    // Coordonnées 2D
     "x": -10,
     "y": -10
   }
 }
 ```
+
 - **Minimum requis** : 3 vertices pour un triangle, 4 pour un rectangle
 - **Convention** : Ordre anti-horaire pour définir l'intérieur du secteur
 - **Précision** : Utiliser des entiers ou décimaux avec max 2 décimales
 
 #### 2. **Secteur (Zone)**
+
 ```json
 {
-  "id": "room_main",           // Identifiant unique
-  "floorHeight": 0,            // Hauteur du sol (Y)
-  "ceilingHeight": 4,          // Hauteur du plafond (Y)
+  "id": "room_main", // Identifiant unique
+  "floorHeight": 0, // Hauteur du sol (Y)
+  "ceilingHeight": 4, // Hauteur du plafond (Y)
   "floorTexture": "FLOOR_MAIN", // Texture du sol
   "ceilingTexture": "CEIL_MAIN", // Texture du plafond
-  "lightLevel": 200,           // Éclairage (0-255)
+  "lightLevel": 200, // Éclairage (0-255)
   "vertices": ["v1", "v2", "v3", "v4"] // Liste des vertices (ordre anti-horaire)
 }
 ```
+
 - **floorHeight < ceilingHeight** : Obligatoire pour éviter les erreurs
 - **lightLevel** : 0 = noir complet, 255 = éclairage max
 - **vertices** : DOIT former un polygone fermé et valide
 
 #### 3. **LineDefs (Murs/Arêtes)**
+
 ```json
 {
-  "id": "wall_south",          // Identifiant unique
-  "startVertex": "v1",         // Vertex de départ
-  "endVertex": "v2",           // Vertex d'arrivée
-  "flags": {                   // Propriétés du mur
-    "blocking": true,          // Collision physique
-    "twoSided": false,         // Mur simple (false) ou passage (true)
-    "dontDraw": false,         // Rendre visible (false) ou invisible (true)
-    "mapped": true,            // Visible sur la carte
-    "soundBlock": false,       // Bloque le son
-    "secret": false,           // Mur secret
-    "lowerUnpegged": false,    // Alignement texture basse
-    "upperUnpegged": false,    // Alignement texture haute
-    "blockMonsters": true      // Bloque les ennemis
+  "id": "wall_south", // Identifiant unique
+  "startVertex": "v1", // Vertex de départ
+  "endVertex": "v2", // Vertex d'arrivée
+  "flags": {
+    // Propriétés du mur
+    "blocking": true, // Collision physique
+    "twoSided": false, // Mur simple (false) ou passage (true)
+    "dontDraw": false, // Rendre visible (false) ou invisible (true)
+    "mapped": true, // Visible sur la carte
+    "soundBlock": false, // Bloque le son
+    "secret": false, // Mur secret
+    "lowerUnpegged": false, // Alignement texture basse
+    "upperUnpegged": false, // Alignement texture haute
+    "blockMonsters": true // Bloque les ennemis
   },
-  "frontSide": {               // Côté intérieur du secteur
+  "frontSide": {
+    // Côté intérieur du secteur
     "id": "wall_south_f",
-    "sector": "room_main",     // Secteur associé
+    "sector": "room_main", // Secteur associé
     "textureMiddle": "WALL_STONE", // Texture principale
-    "textureUpper": "-",       // Texture haute (- = invisible)
-    "textureLower": "-",       // Texture basse (- = invisible)
-    "offsetX": 0,              // Décalage horizontal texture
-    "offsetY": 0,              // Décalage vertical texture
+    "textureUpper": "-", // Texture haute (- = invisible)
+    "textureLower": "-", // Texture basse (- = invisible)
+    "offsetX": 0, // Décalage horizontal texture
+    "offsetY": 0, // Décalage vertical texture
     "needsUpperTexture": false, // Calcul automatique
     "needsLowerTexture": false, // Calcul automatique
-    "needsMiddleTexture": true  // Calcul automatique
+    "needsMiddleTexture": true // Calcul automatique
   },
-  "backSide": null             // null pour mur simple, objet pour passage
+  "backSide": null // null pour mur simple, objet pour passage
 }
 ```
 
 ### Composants Optionnels
 
 #### 4. **Point de Départ Joueur**
+
 ```json
 {
-  "position": {"x": 0, "y": 0}, // Position dans le secteur
-  "angle": 0,                   // Orientation (0-360°)
-  "sector": "room_main"         // Secteur de départ
+  "position": { "x": 0, "y": 0 }, // Position dans le secteur
+  "angle": 0, // Orientation (0-360°)
+  "sector": "room_main" // Secteur de départ
 }
 ```
 
 ## 🔒 Règles et Contraintes Obligatoires
 
 ### Structure du Niveau
+
 ```json
 {
-  "name": "Nom du Niveau",        // OBLIGATOIRE
-  "description": "Description",   // OBLIGATOIRE  
-  "version": "1.0.0",            // OBLIGATOIRE
-  "vertices": [],                // OBLIGATOIRE (min 3)
-  "sectors": [],                 // OBLIGATOIRE (min 1)
-  "lineDefs": [],               // OBLIGATOIRE (min 3)
-  "playerStart": {}             // OBLIGATOIRE
+  "name": "Nom du Niveau", // OBLIGATOIRE
+  "description": "Description", // OBLIGATOIRE
+  "version": "1.0.0", // OBLIGATOIRE
+  "vertices": [], // OBLIGATOIRE (min 3)
+  "sectors": [], // OBLIGATOIRE (min 1)
+  "lineDefs": [], // OBLIGATOIRE (min 3)
+  "playerStart": {} // OBLIGATOIRE
 }
 ```
 
 ### Contraintes Géométriques
 
 #### 1. **Vertices**
+
 - **Unicité** : Chaque `id` doit être unique
 - **Précision** : Coordonnées avec max 2 décimales
 - **Limites** : Éviter les coordonnées extrêmes (±1000)
 
 #### 2. **Secteurs**
+
 - **Polygone valide** : Minimum 3 vertices, ordre anti-horaire
 - **Hauteurs** : `floorHeight < ceilingHeight` (strictement)
 - **Vertices consécutifs** : Pas de vertices dupliqués dans la liste
 - **Fermeture** : Le dernier vertex doit connecter au premier
 
 #### 3. **LineDefs**
+
 - **Couverture complète** : Chaque arête de secteur DOIT avoir un lineDef
 - **Orientation** : `startVertex` → `endVertex` suit le contour anti-horaire
 - **Unicité** : Pas de lineDefs dupliqués sur la même arête
@@ -136,34 +152,37 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
 ### Contraintes de Collision
 
 #### Murs Infranchissables
+
 ```json
 {
   "flags": {
-    "blocking": true,     // OBLIGATOIRE pour collision
-    "twoSided": false     // OBLIGATOIRE pour mur plein
+    "blocking": true, // OBLIGATOIRE pour collision
+    "twoSided": false // OBLIGATOIRE pour mur plein
   },
   "frontSide": {
     "textureMiddle": "WALL_TEXTURE" // OBLIGATOIRE
   },
-  "backSide": null        // OBLIGATOIRE (null)
+  "backSide": null // OBLIGATOIRE (null)
 }
 ```
 
 #### Passages entre Secteurs
+
 ```json
 {
   "flags": {
-    "blocking": false,    // OBLIGATOIRE pour passage
-    "twoSided": true      // OBLIGATOIRE pour connexion
+    "blocking": false, // OBLIGATOIRE pour passage
+    "twoSided": true // OBLIGATOIRE pour connexion
   },
   "frontSide": {
     "sector": "secteur_a",
     "textureMiddle": "-", // Invisible
-    "textureUpper": "WALL_UPPER",  // Si différence hauteur plafond
-    "textureLower": "WALL_LOWER"   // Si différence hauteur sol
+    "textureUpper": "WALL_UPPER", // Si différence hauteur plafond
+    "textureLower": "WALL_LOWER" // Si différence hauteur sol
   },
-  "backSide": {           // OBLIGATOIRE pour twoSided
-    "sector": "secteur_b",
+  "backSide": {
+    // OBLIGATOIRE pour twoSided
+    "sector": "secteur_b"
     // Même structure que frontSide
   }
 }
@@ -172,12 +191,14 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
 ## 📋 Méthodologie Recommandée : Pièce par Pièce
 
 ### Étape 1 : Planification
+
 1. **Dessiner le niveau** sur papier/logiciel 2D
 2. **Définir les secteurs** : Identifier chaque zone fermée
 3. **Numéroter les vertices** : Créer un plan de câblage
 4. **Identifier les connexions** : Portes, passages entre secteurs
 
 ### Étape 2 : Création Incrémentale
+
 ```
 1. Créer UN secteur simple (4 vertices, 4 lineDefs)
 2. Tester le chargement et la navigation
@@ -187,6 +208,7 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
 ```
 
 ### Étape 3 : Validation Continue
+
 - Utiliser `validateLevel()` après chaque ajout
 - Vérifier les logs pour warnings/erreurs
 - Tester ingame pour validation physique
@@ -194,16 +216,17 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
 ## 📝 Exemple Complet : Pièce Simple
 
 ### Pièce Rectangulaire (4x4 unités)
+
 ```json
 {
   "name": "Ma Première Pièce",
   "description": "Pièce rectangulaire simple pour apprendre",
   "version": "1.0.0",
   "vertices": [
-    {"id": "v1", "position": {"x": 0, "y": 0}},
-    {"id": "v2", "position": {"x": 4, "y": 0}},
-    {"id": "v3", "position": {"x": 4, "y": 4}},
-    {"id": "v4", "position": {"x": 0, "y": 4}}
+    { "id": "v1", "position": { "x": 0, "y": 0 } },
+    { "id": "v2", "position": { "x": 4, "y": 0 } },
+    { "id": "v3", "position": { "x": 4, "y": 4 } },
+    { "id": "v4", "position": { "x": 0, "y": 4 } }
   ],
   "sectors": [
     {
@@ -221,65 +244,117 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
       "id": "wall_south",
       "startVertex": "v1",
       "endVertex": "v2",
-      "flags": {"blocking": true, "twoSided": false, "dontDraw": false, "mapped": true, "soundBlock": false, "secret": false, "lowerUnpegged": false, "upperUnpegged": false, "blockMonsters": true},
+      "flags": {
+        "blocking": true,
+        "twoSided": false,
+        "dontDraw": false,
+        "mapped": true,
+        "soundBlock": false,
+        "secret": false,
+        "lowerUnpegged": false,
+        "upperUnpegged": false,
+        "blockMonsters": true
+      },
       "frontSide": {
         "id": "main_south_f",
         "sector": "main_room",
         "textureMiddle": "WALL_BRICK",
         "textureUpper": "-",
         "textureLower": "-",
-        "offsetX": 0, "offsetY": 0,
-        "needsUpperTexture": false, "needsLowerTexture": false, "needsMiddleTexture": true
+        "offsetX": 0,
+        "offsetY": 0,
+        "needsUpperTexture": false,
+        "needsLowerTexture": false,
+        "needsMiddleTexture": true
       }
     },
     {
       "id": "wall_east",
       "startVertex": "v2",
       "endVertex": "v3",
-      "flags": {"blocking": true, "twoSided": false, "dontDraw": false, "mapped": true, "soundBlock": false, "secret": false, "lowerUnpegged": false, "upperUnpegged": false, "blockMonsters": true},
+      "flags": {
+        "blocking": true,
+        "twoSided": false,
+        "dontDraw": false,
+        "mapped": true,
+        "soundBlock": false,
+        "secret": false,
+        "lowerUnpegged": false,
+        "upperUnpegged": false,
+        "blockMonsters": true
+      },
       "frontSide": {
         "id": "main_east_f",
         "sector": "main_room",
         "textureMiddle": "WALL_BRICK",
         "textureUpper": "-",
         "textureLower": "-",
-        "offsetX": 0, "offsetY": 0,
-        "needsUpperTexture": false, "needsLowerTexture": false, "needsMiddleTexture": true
+        "offsetX": 0,
+        "offsetY": 0,
+        "needsUpperTexture": false,
+        "needsLowerTexture": false,
+        "needsMiddleTexture": true
       }
     },
     {
       "id": "wall_north",
       "startVertex": "v3",
       "endVertex": "v4",
-      "flags": {"blocking": true, "twoSided": false, "dontDraw": false, "mapped": true, "soundBlock": false, "secret": false, "lowerUnpegged": false, "upperUnpegged": false, "blockMonsters": true},
+      "flags": {
+        "blocking": true,
+        "twoSided": false,
+        "dontDraw": false,
+        "mapped": true,
+        "soundBlock": false,
+        "secret": false,
+        "lowerUnpegged": false,
+        "upperUnpegged": false,
+        "blockMonsters": true
+      },
       "frontSide": {
         "id": "main_north_f",
         "sector": "main_room",
         "textureMiddle": "WALL_BRICK",
         "textureUpper": "-",
         "textureLower": "-",
-        "offsetX": 0, "offsetY": 0,
-        "needsUpperTexture": false, "needsLowerTexture": false, "needsMiddleTexture": true
+        "offsetX": 0,
+        "offsetY": 0,
+        "needsUpperTexture": false,
+        "needsLowerTexture": false,
+        "needsMiddleTexture": true
       }
     },
     {
       "id": "wall_west",
       "startVertex": "v4",
       "endVertex": "v1",
-      "flags": {"blocking": true, "twoSided": false, "dontDraw": false, "mapped": true, "soundBlock": false, "secret": false, "lowerUnpegged": false, "upperUnpegged": false, "blockMonsters": true},
+      "flags": {
+        "blocking": true,
+        "twoSided": false,
+        "dontDraw": false,
+        "mapped": true,
+        "soundBlock": false,
+        "secret": false,
+        "lowerUnpegged": false,
+        "upperUnpegged": false,
+        "blockMonsters": true
+      },
       "frontSide": {
         "id": "main_west_f",
         "sector": "main_room",
         "textureMiddle": "WALL_BRICK",
         "textureUpper": "-",
         "textureLower": "-",
-        "offsetX": 0, "offsetY": 0,
-        "needsUpperTexture": false, "needsLowerTexture": false, "needsMiddleTexture": true
+        "offsetX": 0,
+        "offsetY": 0,
+        "needsUpperTexture": false,
+        "needsLowerTexture": false,
+        "needsMiddleTexture": true
       }
     }
   ],
   "playerStart": {
-    "position": {"x": 2, "y": 2},
+    "position": { "x": 2, "y": 2 },
     "angle": 0,
     "sector": "main_room"
   }
@@ -287,6 +362,7 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
 ```
 
 **Analyse de cet exemple :**
+
 - ✅ 4 vertices en ordre anti-horaire
 - ✅ 1 secteur avec hauteurs valides (0 < 3)
 - ✅ 4 lineDefs couvrant toutes les arêtes
@@ -303,10 +379,10 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
   "description": "3 connected rooms example",
   "version": "1.0.0",
   "vertices": [
-    {"id": "v1", "position": {"x": -10, "y": -10}},
-    {"id": "v2", "position": {"x": 10, "y": -10}},
-    {"id": "v3", "position": {"x": 10, "y": 10}},
-    {"id": "v4", "position": {"x": -10, "y": 10}}
+    { "id": "v1", "position": { "x": -10, "y": -10 } },
+    { "id": "v2", "position": { "x": 10, "y": -10 } },
+    { "id": "v3", "position": { "x": 10, "y": 10 } },
+    { "id": "v4", "position": { "x": -10, "y": 10 } }
   ],
   "sectors": [
     {
@@ -314,7 +390,7 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
       "floorHeight": 0,
       "ceilingHeight": 4,
       "floorTexture": "FLOOR_MAIN",
-      "ceilingTexture": "CEIL_MAIN", 
+      "ceilingTexture": "CEIL_MAIN",
       "lightLevel": 200,
       "vertices": ["v1", "v2", "v3", "v4"]
     }
@@ -350,7 +426,7 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
     }
   ],
   "playerStart": {
-    "position": {"x": 0, "y": 0},
+    "position": { "x": 0, "y": 0 },
     "angle": 0,
     "sector": "main_room"
   }
@@ -360,11 +436,13 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
 ## ✅ Règles de Cohérence
 
 ### 1. **Orientation des Vertices**
+
 - **Secteurs** : Vertices dans le sens **anti-horaire**
 - **LineDefs** : `startVertex` → `endVertex` suit le contour du secteur
 - **FrontSide** : Toujours du côté intérieur du secteur
 
 ### 2. **Connexions entre Secteurs**
+
 ```json
 {
   "id": "door_connection",
@@ -379,7 +457,7 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
     "textureLower": "WALL_LOWER"
   },
   "backSide": {
-    "sector": "room_b", 
+    "sector": "room_b",
     "textureMiddle": "-",
     "textureUpper": "WALL_UPPER",
     "textureLower": "WALL_LOWER"
@@ -388,13 +466,16 @@ Ce guide explique comment créer des niveaux cohérents et complets pour le mote
 ```
 
 ### 3. **Textures Secteur par Secteur**
+
 - **textureMiddle** : Mur plein (`blocking: true, twoSided: false`)
 - **textureUpper** : Partie haute entre secteurs de hauteurs différentes
 - **textureLower** : Partie basse entre secteurs de hauteurs différentes
 - **"-"** : Pas de texture (invisible)
 
 ### 4. **Validation Automatique**
+
 Le système détecte automatiquement :
+
 - ✅ Vertices manquants
 - ✅ Secteurs sans lineDefs
 - ✅ lineDefs mal orientés
@@ -404,6 +485,7 @@ Le système détecte automatiquement :
 ## 🧪 Workflow de Test
 
 ### Test d'un Secteur Isolé
+
 1. Créer le JSON avec 1 secteur simple
 2. Charger dans le sélecteur de niveau
 3. Vérifier que tous les murs sont visibles
@@ -411,6 +493,7 @@ Le système détecte automatiquement :
 5. Passer au secteur suivant
 
 ### Test de Connexion
+
 1. Ajouter un secteur adjacent
 2. Créer la connexion avec `twoSided: true`
 3. Tester passage bidirectionnel
@@ -418,6 +501,7 @@ Le système détecte automatiquement :
 5. Valider lighting transitions
 
 ### Test de Performance
+
 1. Activer les métriques BSP (`setMetricsEnabled(true)`)
 2. Vérifier culling efficiency dans les logs
 3. S'assurer que FPS reste stable
@@ -426,23 +510,26 @@ Le système détecte automatiquement :
 ## 🛠️ Outils de Debug
 
 ### 1. Validation Automatique
+
 ```typescript
-import { validateLevel } from '@doom-like/engine';
+import { validateLevel } from "@doom-like/engine";
 
 const result = validateLevel(levelData);
 if (!result.isValid) {
-  console.error('Errors:', result.errors);
+  console.error("Errors:", result.errors);
 }
-console.warn('Warnings:', result.warnings);
+console.warn("Warnings:", result.warnings);
 ```
 
 ### 2. Debug BSP
+
 ```typescript
 sceneManager.setDebugBSP(true); // Wireframe partitions
 sceneManager.setMetricsEnabled(true); // Performance metrics
 ```
 
 ### 3. Logs Console
+
 ```
 [LevelValidator] Validation complete: VALID
 [LevelValidator] Errors: 0, Warnings: 2
@@ -454,15 +541,95 @@ sceneManager.setMetricsEnabled(true); // Performance metrics
 ## 📚 Exemples de Référence
 
 ### Niveaux Inclus
+
 1. **`demo_level_phase1.json`** : Niveau simple 2 secteurs
 2. **`test_level_complete.json`** : 3 pièces connectées (référence)
 3. **`physics_playground.json`** : Niveau complexe (problématique, à éviter)
 
 ### Patterns Courants
+
 - **Couloir** : 2 secteurs connectés en ligne
 - **Salle avec piliers** : Secteur principal + obstacles intérieurs
 - **Escaliers** : Secteurs à hauteurs croissantes
 - **Portes interactives** : Configuration spéciale (voir section dédiée)
+
+## 🧩 Éléments Réutilisables (Props) et Éclairage
+
+Cette section décrit des "props" simples (piliers/colonnes) et une configuration d'éclairage modulable que vous pouvez recopier d'un niveau à l'autre.
+
+### 1) Piliers (obstacles intérieurs)
+
+Principe DOOM-like: un pilier est juste un petit secteur fermé à l'intérieur d'un plus grand secteur, avec 4 lineDefs bloquants. Il participe à la collision et au rendu des murs, sans nécessiter de backSide.
+
+Exemple (dans `room_west_corridor`):
+
+```
+// Vertices du pilier
+{"id": "v39", "position": {"x": -19, "y": -1.5}},
+{"id": "v40", "position": {"x": -17, "y": -1.5}},
+{"id": "v41", "position": {"x": -17, "y": 1.5}},
+{"id": "v42", "position": {"x": -19, "y": 1.5}},
+
+// Secteur pilier
+{
+  "id": "pillar_west_a",
+  "floorHeight": 0,
+  "ceilingHeight": 4,
+  "floorTexture": "FLOOR_TILE",
+  "ceilingTexture": "CEIL_MAIN",
+  "lightLevel": 190,
+  "vertices": ["v39", "v40", "v41", "v42"]
+}
+
+// LineDefs (4 côtés, bloquants)
+{
+  "id": "l_pillar_a_1",
+  "startVertex": "v39",
+  "endVertex": "v40",
+  "flags": {"blocking": true, "twoSided": false},
+  "frontSide": {"id": "l_pillar_a_1f", "sector": "pillar_west_a", "textureMiddle": "WALL_BRICK"}
+}
+// ... répéter pour les 3 autres arêtes
+```
+
+Bonnes pratiques:
+
+- Placez les vertices du pilier à l'intérieur du secteur parent, sans toucher ses bords.
+- Utilisez `blocking: true, twoSided: false` pour des murs pleins.
+- Gardez un nommage systématique: `pillar_<zone>_<index>`, `l_pillar_<index>_<1..4>`.
+
+### 2) Éclairage — schéma JSON supporté
+
+Le fichier de niveau peut inclure un bloc `lighting` consommé par `LevelLoader.parseLevel()`.
+
+Structure minimale:
+
+```
+"lighting": {
+  "globalAmbient": {"color": {"r": 0.8, "g": 0.8, "b": 0.85}, "intensity": 0.7},
+  "lights": [
+    {"id": "torch_west_1", "type": "point", "color": {"r":1,"g":0.85,"b":0.6}, "intensity":1.1, "position": {"x": -22, "y": 3, "z": 0}, "range":18, "enabled": true},
+    {"id": "reactor_core", "type": "spot", "color": {"r":0.9,"g":1,"b":0.9}, "intensity":1.3, "position": {"x": -55, "y": 3.5, "z": -20}, "direction": {"x":0,"y":-1,"z":0}, "angle":1.2, "exponent":2, "range":30, "enabled": true}
+  ],
+  "sectorLighting": [
+    {"sectorId": "room_west_corridor", "ambient": {"color": {"r":0.9,"g":0.8,"b":0.7}, "intensity": 0.6}, "lights": ["torch_west_1"]}
+  ],
+  "performance": {"maxActiveLights": 8, "shadowMapPoolSize": 2, "cullingDistance": 25, "enableLOD": true}
+}
+```
+
+Types supportés: `point`, `directional`, `spot`, `hemispheric`.
+
+Conseils:
+
+- Limiter le rayon (`range`) et le nombre de lights actives pour de bonnes perfs.
+- Activer les ombres seulement si nécessaire (coût élevé) via `shadows.enabled`.
+- Harmoniser les `ambient` par secteur pour guider le joueur (zones chaudes/froides).
+
+### 3) Check rapide props/éclairage
+
+- `validateLevel()` ne valide pas le contenu du bloc `lighting` mais loggue les lights/secteurs parsés.
+- Vérifiez en jeu avec `sceneManager.setMetricsEnabled(true)` et/ou l’UI debug lighting si activée.
 
 ## 🚪 Portes Interactives - Configuration Fonctionnelle
 
@@ -474,10 +641,10 @@ Basé sur la porte fonctionnelle du `demo_level_phase1` :
 {
   "id": "l3_door",
   "startVertex": "v7",
-  "endVertex": "v8", 
+  "endVertex": "v8",
   "flags": {
-    "blocking": true,     // CRUCIAL: fermée par défaut
-    "twoSided": true,     // CRUCIAL: visible des deux côtés
+    "blocking": true, // CRUCIAL: fermée par défaut
+    "twoSided": true, // CRUCIAL: visible des deux côtés
     "dontDraw": false,
     "mapped": true,
     "soundBlock": false,
@@ -488,20 +655,20 @@ Basé sur la porte fonctionnelle du `demo_level_phase1` :
   },
   "frontSide": {
     "id": "corridor_door_f",
-    "sector": "corridor",            // Secteur A
-    "textureMiddle": "DOOR_WOOD",    // Texture de porte visible
+    "sector": "corridor", // Secteur A
+    "textureMiddle": "DOOR_WOOD", // Texture de porte visible
     "textureUpper": "-",
-    "textureLower": "WALL_LOWER",    // Base du mur
+    "textureLower": "WALL_LOWER", // Base du mur
     "offsetX": 0,
     "offsetY": 0,
     "needsUpperTexture": false,
-    "needsLowerTexture": true,       // CRUCIAL: afficher la base
-    "needsMiddleTexture": true       // CRUCIAL: afficher la porte
+    "needsLowerTexture": true, // CRUCIAL: afficher la base
+    "needsMiddleTexture": true // CRUCIAL: afficher la porte
   },
   "backSide": {
-    "id": "corridor_door_b", 
-    "sector": "door_room",           // Secteur B (différent!)
-    "textureMiddle": "DOOR_WOOD",    // Même texture
+    "id": "corridor_door_b",
+    "sector": "door_room", // Secteur B (différent!)
+    "textureMiddle": "DOOR_WOOD", // Même texture
     "textureUpper": "-",
     "textureLower": "WALL_LOWER",
     "offsetX": 0,
@@ -535,13 +702,14 @@ Basé sur la porte fonctionnelle du `demo_level_phase1` :
 ### Erreurs courantes ❌
 
 - **Mauvais ID** : Autre que "l3_door" → porte non reconnue
-- **Même secteur** : frontSide et backSide identiques → dysfonctionnement  
+- **Même secteur** : frontSide et backSide identiques → dysfonctionnement
 - **Textures vides** : `textureMiddle: "-"` → porte invisible
 - **Superposition** : Porte ajoutée sur mur existant → z-fighting
 
 ## 🎮 Conseils Pratiques
 
 ### Do ✅
+
 - Commencer simple (1 pièce carrée)
 - Tester après chaque modification
 - Utiliser la validation automatique
@@ -549,6 +717,7 @@ Basé sur la porte fonctionnelle du `demo_level_phase1` :
 - Documenter les connexions complexes
 
 ### Don't ❌
+
 - Créer tous les secteurs d'un coup
 - Ignorer les warnings de validation
 - Dupliquer les lineDefs
@@ -556,6 +725,7 @@ Basé sur la porte fonctionnelle du `demo_level_phase1` :
 - Oublier le playerStart dans un secteur valide
 
 ### En Cas de Problème
+
 1. **Revenir à la dernière version fonctionnelle**
 2. **Isoler le secteur problématique**
 3. **Utiliser validateLevel() pour identifier l'erreur**
@@ -565,6 +735,7 @@ Basé sur la porte fonctionnelle du `demo_level_phase1` :
 ## ✅ Checklist de Validation
 
 ### Avant de Sauvegarder
+
 - [ ] Tous les `id` sont uniques (vertices, sectors, lineDefs, sides)
 - [ ] Vertices en ordre anti-horaire pour chaque secteur
 - [ ] `floorHeight < ceilingHeight` pour tous les secteurs
@@ -574,12 +745,14 @@ Basé sur la porte fonctionnelle du `demo_level_phase1` :
 - [ ] Pas de références cassées (vertices/sectors inexistants)
 
 ### Avant de Tester
+
 - [ ] `validateLevel()` retourne `isValid: true`
 - [ ] Aucune erreur dans les logs de validation
 - [ ] Warnings résolus ou documentés
 - [ ] Textures référencées existent dans le système
 
 ### Pendant le Test
+
 - [ ] Tous les murs sont visibles et solides
 - [ ] Pas de passage à travers les murs (bidirectionnel)
 - [ ] Transitions entre secteurs fonctionnelles
@@ -589,36 +762,42 @@ Basé sur la porte fonctionnelle du `demo_level_phase1` :
 ## 🐛 Erreurs Communes et Solutions
 
 ### "Sector has no lineDefs"
+
 ```
 Cause: Secteur défini sans lineDefs pour ses arêtes
 Solution: Créer un lineDef pour chaque arête du secteur
 ```
 
 ### "Missing vertex reference"
+
 ```
 Cause: Vertex référencé mais non défini dans vertices[]
 Solution: Ajouter le vertex manquant ou corriger la référence
 ```
 
 ### "Invalid sector height"
+
 ```
 Cause: floorHeight >= ceilingHeight
 Solution: Ajuster les hauteurs (ex: floor=0, ceiling=3)
 ```
 
 ### "Player stuck in walls"
+
 ```
 Cause: playerStart en dehors du secteur ou dans un mur
 Solution: Placer playerStart au centre géométrique du secteur
 ```
 
 ### "Flickering walls (Z-fighting)"
+
 ```
 Cause: LineDefs dupliqués ou surfaces superposées
 Solution: Supprimer les doublons, vérifier l'unicité des arêtes
 ```
 
 ### "Cannot enter room from outside"
+
 ```
 Cause: Problème résolu en v0.1.0 - collision bidirectionnelle active
 Solution: Aucune action requise, collision fonctionne dans les deux sens
@@ -628,4 +807,4 @@ Solution: Aucune action requise, collision fonctionne dans les deux sens
 
 **Cette méthode garantit des niveaux stables et jouables ! 🎯**
 
-*Dernière mise à jour : v0.1.0 - Correction collision bidirectionnelle*
+_Dernière mise à jour : v0.1.0 - Correction collision bidirectionnelle_

--- a/packages/engine/src/fixtures/test_level_extended.json
+++ b/packages/engine/src/fixtures/test_level_extended.json
@@ -1371,30 +1371,75 @@
         "enabled": true
       },
       {
+        "id": "exit_light_center",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.14, "b": 0.14 },
+        "intensity": 0.42,
+        "position": { "x": 0, "y": 2.2, "z": 0 },
+        "range": 24,
+        "enabled": true
+      },
+      {
+        "id": "exit_light_west_entry",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.14, "b": 0.14 },
+        "intensity": 0.4,
+        "position": { "x": -17, "y": 2.0, "z": -10 },
+        "range": 18,
+        "enabled": true
+      },
+      {
+        "id": "exit_light_west_platform",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.14, "b": 0.14 },
+        "intensity": 0.4,
+        "position": { "x": -18, "y": 2.0, "z": -20 },
+        "range": 18,
+        "enabled": true
+      },
+      {
+        "id": "exit_light_room_north",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.14, "b": 0.14 },
+        "intensity": 0.38,
+        "position": { "x": 0, "y": 2.0, "z": 15 },
+        "range": 16,
+        "enabled": true
+      },
+      {
+        "id": "exit_light_secret_room",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.12, "b": 0.12 },
+        "intensity": 0.34,
+        "position": { "x": 0, "y": 2.0, "z": 22.5 },
+        "range": 14,
+        "enabled": true
+      },
+      {
         "id": "exit_light_glass_corridor",
         "type": "point",
         "color": { "r": 1.0, "g": 0.15, "b": 0.15 },
-        "intensity": 0.4,
+        "intensity": 0.45,
         "position": { "x": -33.5, "y": 2.0, "z": -20 },
-        "range": 12,
+        "range": 18,
         "enabled": true
       },
       {
         "id": "exit_light_control_room",
         "type": "point",
         "color": { "r": 1.0, "g": 0.12, "b": 0.12 },
-        "intensity": 0.35,
+        "intensity": 0.4,
         "position": { "x": -50, "y": 2.0, "z": -20 },
-        "range": 10,
+        "range": 16,
         "enabled": true
       },
       {
         "id": "exit_light_main_corridor",
         "type": "point",
         "color": { "r": 1.0, "g": 0.16, "b": 0.16 },
-        "intensity": 0.35,
+        "intensity": 0.4,
         "position": { "x": 33, "y": 2.0, "z": 0 },
-        "range": 10,
+        "range": 20,
         "enabled": true
       },
       {
@@ -1472,12 +1517,20 @@
     ],
     "sectorLighting": [
       {
+        "sectorId": "room_main",
+        "ambient": {
+          "color": { "r": 0.8, "g": 0.8, "b": 0.85 },
+          "intensity": 0.65
+        },
+        "lights": ["exit_light_center"]
+      },
+      {
         "sectorId": "room_west_corridor",
         "ambient": {
           "color": { "r": 0.9, "g": 0.8, "b": 0.7 },
           "intensity": 0.6
         },
-        "lights": ["torch_west_1", "torch_west_2"]
+        "lights": ["torch_west_1", "torch_west_2", "exit_light_center"]
       },
       {
         "sectorId": "sector_reactor_room",
@@ -1505,7 +1558,7 @@
           "color": { "r": 0.55, "g": 0.2, "b": 0.2 },
           "intensity": 0.35
         },
-  "lights": ["exit_light_glass_corridor"]
+        "lights": ["exit_light_glass_corridor"]
       },
       {
         "sectorId": "sector_control_room",
@@ -1513,7 +1566,7 @@
           "color": { "r": 0.5, "g": 0.18, "b": 0.18 },
           "intensity": 0.32
         },
-  "lights": ["exit_light_control_room"]
+        "lights": ["exit_light_control_room"]
       },
       {
         "sectorId": "room_west_entry",
@@ -1521,7 +1574,7 @@
           "color": { "r": 0.5, "g": 0.22, "b": 0.2 },
           "intensity": 0.33
         },
-        "lights": []
+        "lights": ["exit_light_west_entry"]
       },
       {
         "sectorId": "room_west_platform",
@@ -1529,7 +1582,7 @@
           "color": { "r": 0.5, "g": 0.22, "b": 0.2 },
           "intensity": 0.33
         },
-        "lights": []
+        "lights": ["exit_light_west_platform"]
       },
       {
         "sectorId": "room_corridor",
@@ -1537,7 +1590,7 @@
           "color": { "r": 0.45, "g": 0.2, "b": 0.2 },
           "intensity": 0.28
         },
-  "lights": ["exit_light_main_corridor"]
+        "lights": ["exit_light_main_corridor", "exit_light_center"]
       },
       {
         "sectorId": "room_north",
@@ -1545,7 +1598,7 @@
           "color": { "r": 0.45, "g": 0.18, "b": 0.22 },
           "intensity": 0.3
         },
-        "lights": []
+        "lights": ["exit_light_room_north"]
       },
       {
         "sectorId": "secret_room",
@@ -1553,7 +1606,7 @@
           "color": { "r": 0.3, "g": 0.35, "b": 0.4 },
           "intensity": 0.2
         },
-        "lights": [],
+        "lights": ["exit_light_secret_room"],
         "fog": {
           "enabled": true,
           "mode": "exponential",
@@ -1565,7 +1618,7 @@
     "performance": {
       "maxActiveLights": 8,
       "shadowMapPoolSize": 2,
-      "cullingDistance": 25,
+      "cullingDistance": 35,
       "enableLOD": true
     }
   }

--- a/packages/engine/src/fixtures/test_level_extended.json
+++ b/packages/engine/src/fixtures/test_level_extended.json
@@ -1363,6 +1363,41 @@
     },
     "lights": [
       {
+        "id": "global_fill",
+        "type": "hemispheric",
+        "color": { "r": 0.35, "g": 0.3, "b": 0.3 },
+        "intensity": 0.18,
+        "direction": { "x": 0, "y": 1, "z": 0 },
+        "enabled": true
+      },
+      {
+        "id": "exit_light_glass_corridor",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.15, "b": 0.15 },
+        "intensity": 0.4,
+        "position": { "x": -33.5, "y": 2.0, "z": -20 },
+        "range": 12,
+        "enabled": true
+      },
+      {
+        "id": "exit_light_control_room",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.12, "b": 0.12 },
+        "intensity": 0.35,
+        "position": { "x": -50, "y": 2.0, "z": -20 },
+        "range": 10,
+        "enabled": true
+      },
+      {
+        "id": "exit_light_main_corridor",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.16, "b": 0.16 },
+        "intensity": 0.35,
+        "position": { "x": 33, "y": 2.0, "z": 0 },
+        "range": 10,
+        "enabled": true
+      },
+      {
         "id": "torch_west_1",
         "type": "point",
         "color": { "r": 1.0, "g": 0.85, "b": 0.6 },
@@ -1463,6 +1498,54 @@
           "intensity": 0.45
         },
         "lights": ["pillar_light_storage_1", "pillar_light_storage_2"]
+      },
+      {
+        "sectorId": "sector_glass_corridor",
+        "ambient": {
+          "color": { "r": 0.55, "g": 0.2, "b": 0.2 },
+          "intensity": 0.35
+        },
+  "lights": ["exit_light_glass_corridor"]
+      },
+      {
+        "sectorId": "sector_control_room",
+        "ambient": {
+          "color": { "r": 0.5, "g": 0.18, "b": 0.18 },
+          "intensity": 0.32
+        },
+  "lights": ["exit_light_control_room"]
+      },
+      {
+        "sectorId": "room_west_entry",
+        "ambient": {
+          "color": { "r": 0.5, "g": 0.22, "b": 0.2 },
+          "intensity": 0.33
+        },
+        "lights": []
+      },
+      {
+        "sectorId": "room_west_platform",
+        "ambient": {
+          "color": { "r": 0.5, "g": 0.22, "b": 0.2 },
+          "intensity": 0.33
+        },
+        "lights": []
+      },
+      {
+        "sectorId": "room_corridor",
+        "ambient": {
+          "color": { "r": 0.45, "g": 0.2, "b": 0.2 },
+          "intensity": 0.28
+        },
+  "lights": ["exit_light_main_corridor"]
+      },
+      {
+        "sectorId": "room_north",
+        "ambient": {
+          "color": { "r": 0.45, "g": 0.18, "b": 0.22 },
+          "intensity": 0.3
+        },
+        "lights": []
       },
       {
         "sectorId": "secret_room",

--- a/packages/engine/src/fixtures/test_level_extended.json
+++ b/packages/engine/src/fixtures/test_level_extended.json
@@ -32,7 +32,39 @@
     { "id": "v27", "position": { "x": -10, "y": -25 } },
     { "id": "v28", "position": { "x": -25, "y": -25 } },
     { "id": "v29", "position": { "x": -15.5, "y": -5 } },
-    { "id": "v30", "position": { "x": -19.5, "y": -5 } }
+    { "id": "v30", "position": { "x": -19.5, "y": -5 } },
+    { "id": "v31", "position": { "x": -40, "y": -15 } },
+    { "id": "v32", "position": { "x": -40, "y": -25 } },
+    { "id": "v33", "position": { "x": -60, "y": -15 } },
+    { "id": "v34", "position": { "x": -60, "y": -25 } },
+    { "id": "v35", "position": { "x": -60, "y": -5 } },
+    { "id": "v36", "position": { "x": -60, "y": -35 } },
+    { "id": "v37", "position": { "x": -70, "y": -35 } },
+    { "id": "v38", "position": { "x": -70, "y": -5 } },
+    { "id": "v39", "position": { "x": -19, "y": -1.5 } },
+    { "id": "v40", "position": { "x": -17, "y": -1.5 } },
+    { "id": "v41", "position": { "x": -17, "y": 1.5 } },
+    { "id": "v42", "position": { "x": -19, "y": 1.5 } },
+    { "id": "v43", "position": { "x": -14.5, "y": -1.5 } },
+    { "id": "v44", "position": { "x": -12.5, "y": -1.5 } },
+    { "id": "v45", "position": { "x": -12.5, "y": 1.5 } },
+    { "id": "v46", "position": { "x": -14.5, "y": 1.5 } },
+    { "id": "v47", "position": { "x": 29.5, "y": 7.5 } },
+    { "id": "v48", "position": { "x": 30.5, "y": 7.5 } },
+    { "id": "v49", "position": { "x": 30.5, "y": 8.5 } },
+    { "id": "v50", "position": { "x": 29.5, "y": 8.5 } },
+    { "id": "v51", "position": { "x": 35, "y": 12 } },
+    { "id": "v52", "position": { "x": 36, "y": 12 } },
+    { "id": "v53", "position": { "x": 36, "y": 13 } },
+    { "id": "v54", "position": { "x": 35, "y": 13 } },
+    { "id": "v55", "position": { "x": -66.5, "y": -10.5 } },
+    { "id": "v56", "position": { "x": -65.5, "y": -10.5 } },
+    { "id": "v57", "position": { "x": -65.5, "y": -9.5 } },
+    { "id": "v58", "position": { "x": -66.5, "y": -9.5 } },
+    { "id": "v59", "position": { "x": -64.5, "y": -30.5 } },
+    { "id": "v60", "position": { "x": -63.5, "y": -30.5 } },
+    { "id": "v61", "position": { "x": -63.5, "y": -29.5 } },
+    { "id": "v62", "position": { "x": -64.5, "y": -29.5 } }
   ],
   "sectors": [
     {
@@ -109,12 +141,93 @@
     },
     {
       "id": "room_west_platform",
-      "floorHeight": 2,
+      "floorHeight": 0,
       "ceilingHeight": 4,
       "floorTexture": "FLOOR_GRATE",
       "ceilingTexture": "CEIL_MAIN",
       "lightLevel": 160,
       "vertices": ["v25", "v27", "v28", "v26"]
+    },
+    {
+      "id": "sector_glass_corridor",
+      "floorHeight": 0,
+      "ceilingHeight": 4,
+      "floorTexture": "FLOOR_TILE",
+      "ceilingTexture": "CEIL_MAIN",
+      "lightLevel": 170,
+      "vertices": ["v26", "v28", "v32", "v31"]
+    },
+    {
+      "id": "sector_control_room",
+      "floorHeight": 0,
+      "ceilingHeight": 4,
+      "floorTexture": "FLOOR_MAIN",
+      "ceilingTexture": "CEIL_HIGH",
+      "lightLevel": 150,
+      "vertices": ["v31", "v32", "v34", "v33"]
+    },
+    {
+      "id": "sector_reactor_room",
+      "floorHeight": 0,
+      "ceilingHeight": 4,
+      "floorTexture": "FLOOR_METAL_BIG",
+      "ceilingTexture": "CEIL_INDUSTRIAL",
+      "lightLevel": 220,
+      "vertices": ["v33", "v34", "v36", "v37", "v38", "v35"]
+    },
+    {
+      "id": "pillar_west_a",
+      "floorHeight": 0,
+      "ceilingHeight": 4,
+      "floorTexture": "FLOOR_TILE",
+      "ceilingTexture": "CEIL_MAIN",
+      "lightLevel": 190,
+      "vertices": ["v39", "v40", "v41", "v42"]
+    },
+    {
+      "id": "pillar_west_b",
+      "floorHeight": 0,
+      "ceilingHeight": 4,
+      "floorTexture": "FLOOR_TILE",
+      "ceilingTexture": "CEIL_MAIN",
+      "lightLevel": 190,
+      "vertices": ["v43", "v44", "v45", "v46"]
+    },
+    {
+      "id": "pillar_storage_a",
+      "floorHeight": 0,
+      "ceilingHeight": 2.5,
+      "floorTexture": "FLOOR_CONCRETE",
+      "ceilingTexture": "CEIL_LOW",
+      "lightLevel": 150,
+      "vertices": ["v47", "v48", "v49", "v50"]
+    },
+    {
+      "id": "pillar_storage_b",
+      "floorHeight": 0,
+      "ceilingHeight": 2.5,
+      "floorTexture": "FLOOR_CONCRETE",
+      "ceilingTexture": "CEIL_LOW",
+      "lightLevel": 150,
+      "vertices": ["v51", "v52", "v53", "v54"]
+    },
+    {
+      "id": "pillar_reactor_a",
+      "floorHeight": 0,
+      "ceilingHeight": 4,
+      "floorTexture": "FLOOR_METAL_BIG",
+      "ceilingTexture": "CEIL_INDUSTRIAL",
+      "lightLevel": 200,
+      "vertices": ["v55", "v56", "v57", "v58"]
+    },
+    {
+      "id": "pillar_reactor_b",
+      "floorHeight": 0,
+      "ceilingHeight": 4,
+      "floorTexture": "FLOOR_METAL_BIG",
+      "ceilingTexture": "CEIL_INDUSTRIAL",
+      "lightLevel": 200,
+      "vertices": ["v59", "v60", "v61", "v62"]
     }
   ],
   "lineDefs": [
@@ -123,14 +236,22 @@
       "startVertex": "v1",
       "endVertex": "v2",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l1f", "sector": "room_main", "textureMiddle": "WALL_STONE" }
+      "frontSide": {
+        "id": "l1f",
+        "sector": "room_main",
+        "textureMiddle": "WALL_STONE"
+      }
     },
     {
       "id": "l2_main_east_lower",
       "startVertex": "v2",
       "endVertex": "v5",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l2f", "sector": "room_main", "textureMiddle": "WALL_STONE" }
+      "frontSide": {
+        "id": "l2f",
+        "sector": "room_main",
+        "textureMiddle": "WALL_STONE"
+      }
     },
     {
       "id": "l3_main_to_east",
@@ -177,14 +298,22 @@
       "startVertex": "v6",
       "endVertex": "v3",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l4f", "sector": "room_main", "textureMiddle": "WALL_STONE" }
+      "frontSide": {
+        "id": "l4f",
+        "sector": "room_main",
+        "textureMiddle": "WALL_STONE"
+      }
     },
     {
       "id": "l5_main_north_east",
       "startVertex": "v3",
       "endVertex": "v10",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l5f", "sector": "room_main", "textureMiddle": "WALL_STONE" }
+      "frontSide": {
+        "id": "l5f",
+        "sector": "room_main",
+        "textureMiddle": "WALL_STONE"
+      }
     },
     {
       "id": "l6_main_to_north",
@@ -231,14 +360,22 @@
       "startVertex": "v9",
       "endVertex": "v4",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l7f", "sector": "room_main", "textureMiddle": "WALL_STONE" }
+      "frontSide": {
+        "id": "l7f",
+        "sector": "room_main",
+        "textureMiddle": "WALL_STONE"
+      }
     },
     {
       "id": "l8_main_west_upper",
       "startVertex": "v4",
       "endVertex": "v19",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l8f", "sector": "room_main", "textureMiddle": "WALL_STONE" }
+      "frontSide": {
+        "id": "l8f",
+        "sector": "room_main",
+        "textureMiddle": "WALL_STONE"
+      }
     },
     {
       "id": "l8a_main_to_west",
@@ -285,14 +422,22 @@
       "startVertex": "v20",
       "endVertex": "v1",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l8bf", "sector": "room_main", "textureMiddle": "WALL_STONE" }
+      "frontSide": {
+        "id": "l8bf",
+        "sector": "room_main",
+        "textureMiddle": "WALL_STONE"
+      }
     },
     {
       "id": "l9_east_north",
       "startVertex": "v6",
       "endVertex": "v7",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l9f", "sector": "room_east", "textureMiddle": "WALL_WOOD" }
+      "frontSide": {
+        "id": "l9f",
+        "sector": "room_east",
+        "textureMiddle": "WALL_WOOD"
+      }
     },
     {
       "id": "l10_east_to_corridor",
@@ -339,14 +484,22 @@
       "startVertex": "v8",
       "endVertex": "v5",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l11f", "sector": "room_east", "textureMiddle": "WALL_WOOD" }
+      "frontSide": {
+        "id": "l11f",
+        "sector": "room_east",
+        "textureMiddle": "WALL_WOOD"
+      }
     },
     {
       "id": "l12_north_west",
       "startVertex": "v12",
       "endVertex": "v9",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l12f", "sector": "room_north", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l12f",
+        "sector": "room_north",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
       "id": "l13_north_to_secret",
@@ -393,28 +546,44 @@
       "startVertex": "v10",
       "endVertex": "v11",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l14f", "sector": "room_north", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l14f",
+        "sector": "room_north",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
       "id": "l15_corridor_south",
       "startVertex": "v8",
       "endVertex": "v14",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l15f", "sector": "room_corridor", "textureMiddle": "WALL_METAL" }
+      "frontSide": {
+        "id": "l15f",
+        "sector": "room_corridor",
+        "textureMiddle": "WALL_METAL"
+      }
     },
     {
       "id": "l16_corridor_east",
       "startVertex": "v14",
       "endVertex": "v13",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l16f", "sector": "room_corridor", "textureMiddle": "WALL_METAL" }
+      "frontSide": {
+        "id": "l16f",
+        "sector": "room_corridor",
+        "textureMiddle": "WALL_METAL"
+      }
     },
     {
       "id": "l17_corridor_north_east",
       "startVertex": "v13",
       "endVertex": "v16",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l17f", "sector": "room_corridor", "textureMiddle": "WALL_METAL" }
+      "frontSide": {
+        "id": "l17f",
+        "sector": "room_corridor",
+        "textureMiddle": "WALL_METAL"
+      }
     },
     {
       "id": "l18_corridor_to_storage",
@@ -461,28 +630,44 @@
       "startVertex": "v15",
       "endVertex": "v7",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l19f", "sector": "room_corridor", "textureMiddle": "WALL_METAL" }
+      "frontSide": {
+        "id": "l19f",
+        "sector": "room_corridor",
+        "textureMiddle": "WALL_METAL"
+      }
     },
     {
       "id": "l20_storage_east",
       "startVertex": "v16",
       "endVertex": "v17",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l20f", "sector": "room_storage", "textureMiddle": "WALL_CONCRETE" }
+      "frontSide": {
+        "id": "l20f",
+        "sector": "room_storage",
+        "textureMiddle": "WALL_CONCRETE"
+      }
     },
     {
       "id": "l21_storage_north",
       "startVertex": "v17",
       "endVertex": "v18",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l21f", "sector": "room_storage", "textureMiddle": "WALL_CONCRETE" }
+      "frontSide": {
+        "id": "l21f",
+        "sector": "room_storage",
+        "textureMiddle": "WALL_CONCRETE"
+      }
     },
     {
       "id": "l22_storage_west",
       "startVertex": "v18",
       "endVertex": "v15",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l22f", "sector": "room_storage", "textureMiddle": "WALL_CONCRETE" }
+      "frontSide": {
+        "id": "l22f",
+        "sector": "room_storage",
+        "textureMiddle": "WALL_CONCRETE"
+      }
     },
     {
       "id": "l_west_wall_1",
@@ -579,42 +764,66 @@
       "startVertex": "v21",
       "endVertex": "v22",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l24f", "sector": "room_west_corridor", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l24f",
+        "sector": "room_west_corridor",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
       "id": "l25_west_corridor_north",
       "startVertex": "v19",
       "endVertex": "v21",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l25f", "sector": "room_west_corridor", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l25f",
+        "sector": "room_west_corridor",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
       "id": "l26_secret_north",
       "startVertex": "v23",
       "endVertex": "v24",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l26f", "sector": "secret_room", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l26f",
+        "sector": "secret_room",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
       "id": "l27_secret_west",
       "startVertex": "v24",
       "endVertex": "v12",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l27f", "sector": "secret_room", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l27f",
+        "sector": "secret_room",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
       "id": "l28_secret_east",
       "startVertex": "v11",
       "endVertex": "v23",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l28f", "sector": "secret_room", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l28f",
+        "sector": "secret_room",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
       "id": "l29_west_entry_east_wall",
       "startVertex": "v25",
       "endVertex": "v20",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l29f", "sector": "room_west_entry", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l29f",
+        "sector": "room_west_entry",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
       "id": "l30_west_platform_step",
@@ -635,24 +844,24 @@
         "id": "l30f",
         "sector": "room_west_entry",
         "textureMiddle": "-",
-        "textureUpper": "WALL_UPPER",
-        "textureLower": "WALL_LOWER",
+        "textureUpper": "-",
+        "textureLower": "-",
         "offsetX": 0,
         "offsetY": 0,
-        "needsUpperTexture": true,
-        "needsLowerTexture": true,
+        "needsUpperTexture": false,
+        "needsLowerTexture": false,
         "needsMiddleTexture": false
       },
       "backSide": {
         "id": "l30b",
         "sector": "room_west_platform",
         "textureMiddle": "-",
-        "textureUpper": "WALL_UPPER",
-        "textureLower": "WALL_LOWER",
+        "textureUpper": "-",
+        "textureLower": "-",
         "offsetX": 0,
         "offsetY": 0,
-        "needsUpperTexture": true,
-        "needsLowerTexture": true,
+        "needsUpperTexture": false,
+        "needsLowerTexture": false,
         "needsMiddleTexture": false
       }
     },
@@ -661,21 +870,42 @@
       "startVertex": "v28",
       "endVertex": "v27",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l31f", "sector": "room_west_platform", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l31f",
+        "sector": "room_west_platform",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
-      "id": "l32_west_platform_west_wall",
+      "id": "l32_platform_to_corridor",
       "startVertex": "v26",
       "endVertex": "v28",
-      "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l32f", "sector": "room_west_platform", "textureMiddle": "WALL_BRICK" }
+      "flags": { "blocking": false, "twoSided": true },
+      "frontSide": {
+        "id": "l32f",
+        "sector": "room_west_platform",
+        "textureMiddle": "-",
+        "textureUpper": "-",
+        "textureLower": "-"
+      },
+      "backSide": {
+        "id": "l32b",
+        "sector": "sector_glass_corridor",
+        "textureMiddle": "-",
+        "textureUpper": "-",
+        "textureLower": "-"
+      }
     },
     {
       "id": "l33_west_platform_east_wall",
       "startVertex": "v27",
       "endVertex": "v25",
       "flags": { "blocking": true, "twoSided": false },
-      "frontSide": { "id": "l33f", "sector": "room_west_platform", "textureMiddle": "WALL_BRICK" }
+      "frontSide": {
+        "id": "l33f",
+        "sector": "room_west_platform",
+        "textureMiddle": "WALL_BRICK"
+      }
     },
     {
       "id": "l34_west_entry_west_wall",
@@ -696,25 +926,428 @@
         "id": "l34f",
         "sector": "room_west_entry",
         "textureMiddle": "WALL_BRICK",
-        "textureUpper": "WALL_UPPER",
-        "textureLower": "WALL_LOWER",
+        "textureUpper": "-",
+        "textureLower": "-",
         "offsetX": 0,
         "offsetY": 0,
-        "needsUpperTexture": true,
-        "needsLowerTexture": true,
+        "needsUpperTexture": false,
+        "needsLowerTexture": false,
         "needsMiddleTexture": true
       },
       "backSide": {
         "id": "l34b",
         "sector": "room_west_platform",
         "textureMiddle": "WALL_BRICK",
-        "textureUpper": "WALL_UPPER",
-        "textureLower": "WALL_LOWER",
+        "textureUpper": "-",
+        "textureLower": "-",
         "offsetX": 0,
         "offsetY": 0,
-        "needsUpperTexture": true,
-        "needsLowerTexture": true,
+        "needsUpperTexture": false,
+        "needsLowerTexture": false,
         "needsMiddleTexture": true
+      }
+    },
+    {
+      "id": "l35_glass_corridor_south",
+      "startVertex": "v32",
+      "endVertex": "v28",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l35f",
+        "sector": "sector_glass_corridor",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l37_glass_corridor_north",
+      "startVertex": "v26",
+      "endVertex": "v31",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l37f",
+        "sector": "sector_glass_corridor",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l38_corridor_to_control",
+      "startVertex": "v31",
+      "endVertex": "v32",
+      "flags": { "blocking": false, "twoSided": true },
+      "frontSide": {
+        "id": "l38f",
+        "sector": "sector_glass_corridor",
+        "textureMiddle": "-",
+        "textureUpper": "WALL_BRICK",
+        "textureLower": "-"
+      },
+      "backSide": {
+        "id": "l38b",
+        "sector": "sector_control_room",
+        "textureMiddle": "-",
+        "textureUpper": "WALL_BRICK",
+        "textureLower": "-"
+      }
+    },
+    {
+      "id": "l39_control_room_south",
+      "startVertex": "v32",
+      "endVertex": "v34",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l39f",
+        "sector": "sector_control_room",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l40_control_to_reactor",
+      "startVertex": "v33",
+      "endVertex": "v34",
+      "flags": { "blocking": false, "twoSided": true },
+      "frontSide": {
+        "id": "l40f",
+        "sector": "sector_control_room",
+        "textureMiddle": "-",
+        "textureUpper": "WALL_BRICK",
+        "textureLower": "-"
+      },
+      "backSide": {
+        "id": "l40b",
+        "sector": "sector_reactor_room",
+        "textureMiddle": "-",
+        "textureUpper": "WALL_BRICK",
+        "textureLower": "-"
+      }
+    },
+    {
+      "id": "l41_control_room_north",
+      "startVertex": "v31",
+      "endVertex": "v33",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l41f",
+        "sector": "sector_control_room",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l42_reactor_south",
+      "startVertex": "v34",
+      "endVertex": "v36",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l42f",
+        "sector": "sector_reactor_room",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l43_reactor_south_west",
+      "startVertex": "v36",
+      "endVertex": "v37",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l43f",
+        "sector": "sector_reactor_room",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l44_reactor_switch",
+      "startVertex": "v37",
+      "endVertex": "v38",
+      "flags": { "blocking": true, "twoSided": false, "secret": true },
+      "frontSide": {
+        "id": "l44f",
+        "sector": "sector_reactor_room",
+        "textureMiddle": "SWITCH_ON"
+      }
+    },
+    {
+      "id": "l45_reactor_north_west",
+      "startVertex": "v38",
+      "endVertex": "v35",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l45f",
+        "sector": "sector_reactor_room",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l46_reactor_north",
+      "startVertex": "v35",
+      "endVertex": "v33",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l46f",
+        "sector": "sector_reactor_room",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l_pillar_a_1",
+      "startVertex": "v39",
+      "endVertex": "v40",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_a_1f",
+        "sector": "pillar_west_a",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l_pillar_a_2",
+      "startVertex": "v40",
+      "endVertex": "v41",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_a_2f",
+        "sector": "pillar_west_a",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l_pillar_a_3",
+      "startVertex": "v41",
+      "endVertex": "v42",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_a_3f",
+        "sector": "pillar_west_a",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l_pillar_a_4",
+      "startVertex": "v42",
+      "endVertex": "v39",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_a_4f",
+        "sector": "pillar_west_a",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l_pillar_b_1",
+      "startVertex": "v43",
+      "endVertex": "v44",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_b_1f",
+        "sector": "pillar_west_b",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l_pillar_b_2",
+      "startVertex": "v44",
+      "endVertex": "v45",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_b_2f",
+        "sector": "pillar_west_b",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l_pillar_b_3",
+      "startVertex": "v45",
+      "endVertex": "v46",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_b_3f",
+        "sector": "pillar_west_b",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l_pillar_b_4",
+      "startVertex": "v46",
+      "endVertex": "v43",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_b_4f",
+        "sector": "pillar_west_b",
+        "textureMiddle": "WALL_BRICK"
+      }
+    },
+    {
+      "id": "l_pillar_storage_a_1",
+      "startVertex": "v47",
+      "endVertex": "v48",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_storage_a_1f",
+        "sector": "pillar_storage_a",
+        "textureMiddle": "WALL_CONCRETE"
+      }
+    },
+    {
+      "id": "l_pillar_storage_a_2",
+      "startVertex": "v48",
+      "endVertex": "v49",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_storage_a_2f",
+        "sector": "pillar_storage_a",
+        "textureMiddle": "WALL_CONCRETE"
+      }
+    },
+    {
+      "id": "l_pillar_storage_a_3",
+      "startVertex": "v49",
+      "endVertex": "v50",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_storage_a_3f",
+        "sector": "pillar_storage_a",
+        "textureMiddle": "WALL_CONCRETE"
+      }
+    },
+    {
+      "id": "l_pillar_storage_a_4",
+      "startVertex": "v50",
+      "endVertex": "v47",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_storage_a_4f",
+        "sector": "pillar_storage_a",
+        "textureMiddle": "WALL_CONCRETE"
+      }
+    },
+    {
+      "id": "l_pillar_storage_b_1",
+      "startVertex": "v51",
+      "endVertex": "v52",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_storage_b_1f",
+        "sector": "pillar_storage_b",
+        "textureMiddle": "WALL_CONCRETE"
+      }
+    },
+    {
+      "id": "l_pillar_storage_b_2",
+      "startVertex": "v52",
+      "endVertex": "v53",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_storage_b_2f",
+        "sector": "pillar_storage_b",
+        "textureMiddle": "WALL_CONCRETE"
+      }
+    },
+    {
+      "id": "l_pillar_storage_b_3",
+      "startVertex": "v53",
+      "endVertex": "v54",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_storage_b_3f",
+        "sector": "pillar_storage_b",
+        "textureMiddle": "WALL_CONCRETE"
+      }
+    },
+    {
+      "id": "l_pillar_storage_b_4",
+      "startVertex": "v54",
+      "endVertex": "v51",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_storage_b_4f",
+        "sector": "pillar_storage_b",
+        "textureMiddle": "WALL_CONCRETE"
+      }
+    },
+    {
+      "id": "l_pillar_reactor_a_1",
+      "startVertex": "v55",
+      "endVertex": "v56",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_reactor_a_1f",
+        "sector": "pillar_reactor_a",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l_pillar_reactor_a_2",
+      "startVertex": "v56",
+      "endVertex": "v57",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_reactor_a_2f",
+        "sector": "pillar_reactor_a",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l_pillar_reactor_a_3",
+      "startVertex": "v57",
+      "endVertex": "v58",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_reactor_a_3f",
+        "sector": "pillar_reactor_a",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l_pillar_reactor_a_4",
+      "startVertex": "v58",
+      "endVertex": "v55",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_reactor_a_4f",
+        "sector": "pillar_reactor_a",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l_pillar_reactor_b_1",
+      "startVertex": "v59",
+      "endVertex": "v60",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_reactor_b_1f",
+        "sector": "pillar_reactor_b",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l_pillar_reactor_b_2",
+      "startVertex": "v60",
+      "endVertex": "v61",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_reactor_b_2f",
+        "sector": "pillar_reactor_b",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l_pillar_reactor_b_3",
+      "startVertex": "v61",
+      "endVertex": "v62",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_reactor_b_3f",
+        "sector": "pillar_reactor_b",
+        "textureMiddle": "WALL_METAL"
+      }
+    },
+    {
+      "id": "l_pillar_reactor_b_4",
+      "startVertex": "v62",
+      "endVertex": "v59",
+      "flags": { "blocking": true, "twoSided": false },
+      "frontSide": {
+        "id": "l_pillar_reactor_b_4f",
+        "sector": "pillar_reactor_b",
+        "textureMiddle": "WALL_METAL"
       }
     }
   ],
@@ -722,5 +1355,135 @@
     "position": { "x": 0, "y": 0 },
     "angle": 0,
     "sector": "room_main"
+  },
+  "lighting": {
+    "globalAmbient": {
+      "color": { "r": 0.8, "g": 0.8, "b": 0.85 },
+      "intensity": 0.7
+    },
+    "lights": [
+      {
+        "id": "torch_west_1",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.85, "b": 0.6 },
+        "intensity": 1.1,
+        "position": { "x": -22, "y": 3, "z": 0 },
+        "range": 18,
+        "enabled": true
+      },
+      {
+        "id": "torch_west_2",
+        "type": "point",
+        "color": { "r": 1.0, "g": 0.85, "b": 0.6 },
+        "intensity": 1.1,
+        "position": { "x": -13, "y": 3, "z": 0 },
+        "range": 18,
+        "enabled": true
+      },
+      {
+        "id": "reactor_core",
+        "type": "spot",
+        "color": { "r": 0.9, "g": 1.0, "b": 0.9 },
+        "intensity": 1.3,
+        "position": { "x": -55, "y": 3.5, "z": -20 },
+        "direction": { "x": 0, "y": -1, "z": 0 },
+        "angle": 1.2,
+        "exponent": 2,
+        "range": 30,
+        "enabled": true,
+        "shadows": {
+          "enabled": false,
+          "mapSize": 1024,
+          "bias": 0.0001,
+          "darkness": 0.2
+        }
+      },
+      {
+        "id": "pillar_light_storage_1",
+        "type": "point",
+        "color": { "r": 0.9, "g": 0.95, "b": 1.0 },
+        "intensity": 0.9,
+        "position": { "x": 30, "y": 2.2, "z": 8 },
+        "range": 14,
+        "enabled": true
+      },
+      {
+        "id": "pillar_light_storage_2",
+        "type": "point",
+        "color": { "r": 0.9, "g": 0.95, "b": 1.0 },
+        "intensity": 0.9,
+        "position": { "x": 35.5, "y": 2.2, "z": 12.5 },
+        "range": 14,
+        "enabled": true
+      },
+      {
+        "id": "pillar_light_reactor_1",
+        "type": "point",
+        "color": { "r": 0.8, "g": 0.9, "b": 1.0 },
+        "intensity": 1.0,
+        "position": { "x": -66, "y": 3.5, "z": -10 },
+        "range": 16,
+        "enabled": true
+      },
+      {
+        "id": "pillar_light_reactor_2",
+        "type": "point",
+        "color": { "r": 0.8, "g": 0.9, "b": 1.0 },
+        "intensity": 1.0,
+        "position": { "x": -64, "y": 3.5, "z": -30 },
+        "range": 16,
+        "enabled": true
+      }
+    ],
+    "sectorLighting": [
+      {
+        "sectorId": "room_west_corridor",
+        "ambient": {
+          "color": { "r": 0.9, "g": 0.8, "b": 0.7 },
+          "intensity": 0.6
+        },
+        "lights": ["torch_west_1", "torch_west_2"]
+      },
+      {
+        "sectorId": "sector_reactor_room",
+        "ambient": {
+          "color": { "r": 0.8, "g": 0.9, "b": 0.8 },
+          "intensity": 0.5
+        },
+        "lights": [
+          "reactor_core",
+          "pillar_light_reactor_1",
+          "pillar_light_reactor_2"
+        ]
+      },
+      {
+        "sectorId": "room_storage",
+        "ambient": {
+          "color": { "r": 0.85, "g": 0.9, "b": 1.0 },
+          "intensity": 0.45
+        },
+        "lights": ["pillar_light_storage_1", "pillar_light_storage_2"]
+      },
+      {
+        "sectorId": "secret_room",
+        "ambient": {
+          "color": { "r": 0.3, "g": 0.35, "b": 0.4 },
+          "intensity": 0.2
+        },
+        "lights": [],
+        "fog": {
+          "enabled": true,
+          "mode": "exponential",
+          "color": { "r": 0.05, "g": 0.06, "b": 0.07 },
+          "density": 0.03
+        }
+      }
+    ],
+    "performance": {
+      "maxActiveLights": 8,
+      "shadowMapPoolSize": 2,
+      "cullingDistance": 25,
+      "enableLOD": true
+    }
   }
 }

--- a/packages/engine/src/fixtures/test_level_extended.json
+++ b/packages/engine/src/fixtures/test_level_extended.json
@@ -1538,11 +1538,7 @@
           "color": { "r": 0.8, "g": 0.9, "b": 0.8 },
           "intensity": 0.5
         },
-        "lights": [
-          "reactor_core",
-          "pillar_light_reactor_1",
-          "pillar_light_reactor_2"
-        ]
+        "lights": ["reactor_core", "pillar_light_reactor_1", "pillar_light_reactor_2"]
       },
       {
         "sectorId": "room_storage",

--- a/packages/engine/src/lighting/sector-lighting.ts
+++ b/packages/engine/src/lighting/sector-lighting.ts
@@ -3,7 +3,7 @@ import type { DoomSector } from '../geometry/doom-geometry';
 import { Logger } from '../utils/logger';
 import type { FogManager } from './fog-manager';
 import type { LightManager } from './light-manager';
-import type { FogConfig, LightTransition, SectorLightingConfig } from './types';
+import type { FogConfig, LightInstance, LightTransition, SectorLightingConfig } from './types';
 
 export class SectorLightingManager {
   private scene: Scene;
@@ -196,10 +196,7 @@ export class SectorLightingManager {
     this.setFog(config.fog);
 
     for (const [lightId, light] of this.lightManager.getAllLights()) {
-      const isGlobal =
-        (light.config.type === 'hemispheric' || light.config.type === 'directional') &&
-        light.config.id.startsWith('global_');
-      const shouldBeEnabled = isGlobal || config.lights.includes(lightId);
+      const shouldBeEnabled = this._isGlobalLight(light) || config.lights.includes(lightId);
       this.lightManager.setLightEnabled(lightId, shouldBeEnabled);
     }
   }
@@ -271,12 +268,8 @@ export class SectorLightingManager {
     const toLights = new Set(to.lights);
 
     for (const [lightId, light] of this.lightManager.getAllLights()) {
-      const isGlobal =
-        (light.config.type === 'hemispheric' || light.config.type === 'directional') &&
-        light.config.id.startsWith('global_');
-
       // Keep global lights always enabled as a safety baseline
-      if (isGlobal) {
+      if (this._isGlobalLight(light)) {
         this.lightManager.setLightEnabled(lightId, true);
         continue;
       }
@@ -298,6 +291,13 @@ export class SectorLightingManager {
         }
       }
     }
+  }
+
+  private _isGlobalLight(light: LightInstance): boolean {
+    return (
+      (light.config.type === 'hemispheric' || light.config.type === 'directional') &&
+      light.config.id.startsWith('global_')
+    );
   }
 
   // Fog transition management is now delegated to FogManager

--- a/packages/engine/src/lighting/sector-lighting.ts
+++ b/packages/engine/src/lighting/sector-lighting.ts
@@ -195,8 +195,11 @@ export class SectorLightingManager {
     this.setAmbientLighting(config.ambient.color, config.ambient.intensity);
     this.setFog(config.fog);
 
-    for (const [lightId, _light] of this.lightManager.getAllLights()) {
-      const shouldBeEnabled = config.lights.includes(lightId);
+    for (const [lightId, light] of this.lightManager.getAllLights()) {
+      const isGlobal =
+        (light.config.type === 'hemispheric' || light.config.type === 'directional') &&
+        light.config.id.startsWith('global_');
+      const shouldBeEnabled = isGlobal || config.lights.includes(lightId);
       this.lightManager.setLightEnabled(lightId, shouldBeEnabled);
     }
   }
@@ -267,7 +270,17 @@ export class SectorLightingManager {
     const fromLights = new Set(from?.lights || []);
     const toLights = new Set(to.lights);
 
-    for (const [lightId] of this.lightManager.getAllLights()) {
+    for (const [lightId, light] of this.lightManager.getAllLights()) {
+      const isGlobal =
+        (light.config.type === 'hemispheric' || light.config.type === 'directional') &&
+        light.config.id.startsWith('global_');
+
+      // Keep global lights always enabled as a safety baseline
+      if (isGlobal) {
+        this.lightManager.setLightEnabled(lightId, true);
+        continue;
+      }
+
       const wasEnabled = fromLights.has(lightId);
       const willBeEnabled = toLights.has(lightId);
 


### PR DESCRIPTION
Résumé

- Ajout de balises rouges (points lumineux) dans toutes les zones sombres + augmentation portée/intensité pour visibilité à distance.
- Pylônes lumineux et ambiances rouges subtiles dans les pièces d’extrémité.
- Correctif blackout: seuls les lights hémisphériques/directionnels préfixés global_* restent toujours actifs + ajout de global_fill.
- Réparation du JSON corrompu (engine fixture) et miroir exact côté web.
- App web: niveau par défaut basculé sur test_level_extended + sélecteur mis à jour.

Qualité & vérifs

- Unit tests moteur: PASS (33 fichiers, 412 tests).
- E2E Playwright: PASS (6 tests) après installation des navigateurs.
- Build monorepo: PASS.
- Fixtures JSON: validées et synchronisées engine/web.

Impacts & risques

- Plus de points lumineux actifs; config perf ajustée (maxActiveLights=8, cullingDistance=35).
- Pas d’impact sur WAD loader (WIP).

Comment tester

1) pnpm install
2) pnpm dev (web) et charger "Test Level Extended" (par défaut).
3) Vérifier visibilité des balises rouges à distance, ambiance sombre conservée, aucun blackout lors des transitions.

Checklist

- [x] Tests unitaires verts
- [x] E2E basiques verts
- [x] Fixtures engine/web synchronisées
- [x] Rendu stable (global_fill actif)
